### PR TITLE
Set up environment variables

### DIFF
--- a/apps/site/src/app/(home)/page.tsx
+++ b/apps/site/src/app/(home)/page.tsx
@@ -1,5 +1,7 @@
 import { Landing } from "./sections";
 
 export default function Home() {
-	return <Landing />;
+	// Show landing section only if still in maintenance,
+	// otherwise show the rest of the sections
+	return process.env.MAINTENANCE_MODE_HOME ? <Landing /> : <Landing />;
 }


### PR DESCRIPTION
Resolves #19 .

I've only set up the one for the landing page since that's what we're working on right now, but I'll create a separate issue for the application page when we start working on it.

The `process.env.MAINTENANCE_MODE_HOME` will be added to the production only builds of Vercel, which means that you'll still be able to see everything on local development environments and preview builds, but not production.