### PR TITLE
Configure API to work on Vercel from Next SSR

### DIFF
--- a/apps/api/requirements.txt
+++ b/apps/api/requirements.txt
@@ -1,1 +1,2 @@
 fastapi==0.104.1
+python-multipart==0.0.5

--- a/apps/api/src/app.py
+++ b/apps/api/src/app.py
@@ -1,6 +1,10 @@
 from fastapi import FastAPI
 
+from routers import demo
+
 app = FastAPI()
+
+app.include_router(demo.router, prefix="/demo", tags=["demo"])
 
 
 @app.get("/")

--- a/apps/api/src/dev.py
+++ b/apps/api/src/dev.py
@@ -3,6 +3,7 @@ import uvicorn
 if __name__ == "__main__":
     uvicorn.run(
         "app:app",
+        host="localhost",
         log_level="info",
         access_log=True,
         use_colors=True,

--- a/apps/api/src/routers/demo.py
+++ b/apps/api/src/routers/demo.py
@@ -1,0 +1,17 @@
+from typing import Annotated, Union
+
+from fastapi import APIRouter, Cookie, Form
+
+router = APIRouter()
+
+
+@router.get("/me")
+async def me(username: Annotated[Union[str, None], Cookie()] = None) -> str:
+    """Who are you?"""
+    return f"You are {username or 'nobody'}"
+
+
+@router.post("/square")
+async def square(value: Annotated[int, Form()]) -> int:
+    """Calculate the square of the value."""
+    return value * value

--- a/apps/site/next.config.js
+++ b/apps/site/next.config.js
@@ -1,4 +1,25 @@
-/** @type {import('next').NextConfig} */
-const nextConfig = {}
+// All server-side API requests are handled by lib/utils/api.ts
+// but this rewrite still exists for locally testing native POST requests
+const LOCAL_API_URL = "http://localhost:8000";
 
-module.exports = nextConfig
+// When deployed on Vercel, this path acts like a rewrite in vercel.json
+// Next.js would normally be unable to find the API endpoint
+// but Vercel somehow steps in and makes the Serverless Function visible
+const VERCEL_API_PATH = "/api/";
+
+/** @type {import('next').NextConfig} */
+const nextConfig = {
+	rewrites: async () => {
+		return [
+			{
+				source: "/api/:path*",
+				destination:
+					process.env.NODE_ENV === "development"
+						? `${LOCAL_API_URL}/:path*`
+						: VERCEL_API_PATH,
+			},
+		];
+	},
+};
+
+module.exports = nextConfig;

--- a/apps/site/package.json
+++ b/apps/site/package.json
@@ -19,6 +19,7 @@
 		"@react-three/drei": "^9.88.14",
 		"@react-three/fiber": "^8.15.11",
 		"@types/three": "^0.158.2",
+		"axios": "^1.6.2",
 		"clsx": "^2.0.0",
 		"lucide-react": "^0.292.0",
 		"next": "13.5.6",

--- a/apps/site/src/app/demo/Demo.tsx
+++ b/apps/site/src/app/demo/Demo.tsx
@@ -1,0 +1,21 @@
+import api from "@/lib/utils/api";
+
+async function getMessage(): Promise<string> {
+	const res = await api.get<string>("/demo/me");
+	return res.data;
+}
+
+async function Demo() {
+	const message = await getMessage();
+	return (
+		<div>
+			<p>Demo: {message}</p>
+			<form method="post" action="/api/demo/square">
+				<input type="number" required name="value" style={{ color: "black" }} />
+				<button type="submit">Submit</button>
+			</form>
+		</div>
+	);
+}
+
+export default Demo;

--- a/apps/site/src/app/demo/page.js
+++ b/apps/site/src/app/demo/page.js
@@ -1,0 +1,1 @@
+export { default as default } from "./Demo";

--- a/apps/site/src/lib/utils/api.ts
+++ b/apps/site/src/lib/utils/api.ts
@@ -1,0 +1,24 @@
+import axios from "axios";
+import { cookies } from "next/headers";
+
+const LOCAL_API_URL = "http://localhost:8000";
+const SERVER_HOST = process.env.NEXT_PUBLIC_VERCEL_URL;
+
+// The Vercel Serverless Function for the API lives outside the scope of Next.js
+// so the publicly deployed URL must be used instead of a rewrite
+const api = axios.create({
+	baseURL: SERVER_HOST ? `https://${SERVER_HOST}/api/` : LOCAL_API_URL,
+});
+
+api.interceptors.request.use((config) => {
+	const cookieStore = cookies();
+
+	// Inject user's client-side cookies along with API request
+	const provided = config.headers.get("Cookie");
+	const newCookies = (provided ? `${provided}; ` : "") + cookieStore.toString();
+	config.headers.set("Cookie", newCookies);
+
+	return config;
+});
+
+export default api;

--- a/apps/site/vercel.json
+++ b/apps/site/vercel.json
@@ -1,6 +1,5 @@
 {
 	"buildCommand": "cd ../.. && turbo run build --filter={apps/site} && cd apps/site && ./copy-api.sh",
-	"rewrites": [{ "source": "/api/(.*)", "destination": "api/index.py" }],
 	"functions": {
 		"api/index.py": {
 			"memory": 512,

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -110,6 +110,9 @@ importers:
       '@types/three':
         specifier: ^0.158.2
         version: 0.158.2
+      axios:
+        specifier: ^1.6.2
+        version: 1.6.2
       clsx:
         specifier: ^2.0.0
         version: 2.0.0
@@ -4717,6 +4720,16 @@ packages:
     engines: {node: '>=4'}
     dev: true
 
+  /axios@1.6.2:
+    resolution: {integrity: sha512-7i24Ri4pmDRfJTR7LDBhsOTtcm+9kjX5WiY1X3wIisx6G9So3pfMkEiU7emUBe46oceVImccTEM3k6C5dbVW8A==}
+    dependencies:
+      follow-redirects: 1.15.3(debug@4.3.4)
+      form-data: 4.0.0
+      proxy-from-env: 1.1.0
+    transitivePeerDependencies:
+      - debug
+    dev: false
+
   /axobject-query@3.1.1:
     resolution: {integrity: sha512-goKlv8DZrK9hUh975fnHzhNIO4jUnFCfv/dszV5VwUGDFjI6vQ2VwoyjYjYNEbBE8AH87TduWP5uyDR1D+Iteg==}
     dependencies:
@@ -8852,7 +8865,6 @@ packages:
 
   /proxy-from-env@1.1.0:
     resolution: {integrity: sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==}
-    dev: true
 
   /psl@1.9.0:
     resolution: {integrity: sha512-E/ZsdU4HLs/68gYzgGTkMicWTLPdAftJLfJFlLUAAKZGkStNU72sZjT66SnMDVOfOWY/YAoiD7Jxa9iHvngcag==}


### PR DESCRIPTION
## Changes
- Set up axios instance to use correct public Vercel URL for API calls during server-side rendering
  - Inject user's client-side cookies during API request
- Create demo example to illustrate server-side API call with axios and a native POST request from the client
- Update Uvicorn `host` to resolve IPv6 issues
- Configure Next rewrite which acts like a Vercel rewrite
  - This allows for local client-side testing of API endpoints and makes the API paths publicly accessible at `/api/`

## Testing
Clone the branch locally and visit `/demo` while also having the local API server running with Uvicorn
- Observe the dynamic response text when providing a cookie with the name `username`
- Try entering a number in the input field and submitting the form

Visit `/demo` in the deployed preview
- Observe the same behavior as in the development environment