### PR TITLE
Add workflow to run checks for the API and site

### DIFF
--- a/.env
+++ b/.env
@@ -1,1 +1,2 @@
+# For VS Code Python extension
 PYTHONPATH=apps/api/src

--- a/.github/workflows/deploy-prod.yml
+++ b/.github/workflows/deploy-prod.yml
@@ -1,7 +1,11 @@
 name: Deploy Production
 
 on:
-    push:
+    workflow_run:
+        workflows:
+            - Run Checks
+        types:
+            - completed
         branches:
             - main
 

--- a/.github/workflows/run-checks.yml
+++ b/.github/workflows/run-checks.yml
@@ -1,0 +1,126 @@
+name: Run Checks
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    branches:
+      - main
+
+jobs:
+  check-api:
+    name: Check API
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: apps/api
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.9"
+          cache: "pip"
+          cache-dependency-path: |
+            apps/api/requirements.txt
+            apps/api/requirements-dev.txt
+
+      - name: Install xmlsec dependencies
+        uses: awalsh128/cache-apt-pkgs-action@latest
+        with:
+          packages: libxml2-dev libxmlsec1-dev libxmlsec1-openssl
+          version: 1.0
+
+      - name: Install Python dependencies
+        run: pip install -r requirements.txt -r requirements-dev.txt
+
+      - name: Format with Black
+        uses: reviewdog/action-black@v3
+        with:
+          workdir: apps/api
+          level: warning
+          reporter: github-pr-review
+
+      - name: Lint with flake8
+        uses: reviewdog/action-flake8@v3
+        with:
+          workdir: apps/api
+          level: warning
+          reporter: github-pr-review
+
+      - name: Cache `.mypy_cache`
+        uses: actions/cache@v3
+        with:
+          path: ${{ github.workspace }}/.mypy_cache
+          key: ${{ runner.os }}-python3.9-mypy-cache
+
+      - name: Lint with mypy (review)
+        uses: tsuyoshicho/action-mypy@v4
+        if: github.event_name == 'pull_request'
+        with:
+          workdir: apps/api
+          level: error
+          reporter: github-pr-review
+
+      - name: Run mypy (check)
+        uses: tsuyoshicho/action-mypy@v4
+        if: github.event_name == 'push'
+        with:
+          workdir: apps/api
+          level: error
+          reporter: github-check
+
+      - name: Run tests with pytest
+        run: pytest
+        # uses: reviewdog/action-pytest@v1 (WIP)
+        # with:
+        #   reporter: github-pr-review
+        #   level: error
+
+  check-frontend:
+    name: Check Site
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - name: Set up pnpm
+        uses: pnpm/action-setup@v2
+        with:
+          version: 8
+
+      - name: Set up Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: "pnpm"
+
+      - name: Install frontend dependencies
+        run: pnpm install
+
+      - name: Format with Prettier
+        uses: EPMatt/reviewdog-action-prettier@v1
+        with:
+          level: warning
+          reporter: github-pr-review
+          prettier_flags: apps/site/src
+
+      - name: Lint with ESLint (review)
+        uses: reviewdog/action-eslint@v1
+        if: github.event_name == 'pull_request'
+        with:
+          level: error
+          reporter: github-pr-review
+          eslint_flags: apps/site/src
+
+      - name: Lint with ESLint (check)
+        uses: reviewdog/action-eslint@v1
+        if: github.event_name == 'push'
+        with:
+          workDir: apps/site
+          level: error
+          reporter: github-check
+          eslint_flags: src

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -6,4 +6,9 @@
 	],
 	"python.envFile": "${workspaceFolder}/.env",
 	"python.defaultInterpreterPath": ".venv/bin/python",
+	"python.testing.pytestEnabled": true,
+	"mypy-type-checker.cwd": "${workspaceFolder}/apps/api",
+	"flake8.cwd": "${workspaceFolder}/apps/api",
+	"isort.args": ["--settings-path", "apps/api/pyproject.toml"],
+	"python.testing.pytestArgs": ["--rootdir", "apps/api"]
 }

--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -3,6 +3,9 @@
 	"private": true,
 	"scripts": {
 		"dev": "python src/dev.py",
-		"test": "pytest"
+		"test": "pytest",
+		"lint": "flake8 src tests && mypy src tests",
+		"format:write": "black src tests",
+		"format:check": "black --check src tests"
 	}
 }

--- a/apps/api/pyproject.toml
+++ b/apps/api/pyproject.toml
@@ -1,3 +1,7 @@
+[tool.isort]
+profile = "black"
+src_paths = "src"
+
 [tool.pytest.ini_options]
 pythonpath = "src"
 addopts = "--verbose --cov src"
@@ -9,3 +13,8 @@ branch = true
 
 [tool.coverage.report]
 show_missing = true
+
+[tool.mypy]
+mypy_path = "src"
+explicit_package_bases = true
+strict = true

--- a/apps/api/requirements-dev.txt
+++ b/apps/api/requirements-dev.txt
@@ -1,5 +1,8 @@
+black==23.11.0
+flake8==6.1.0
+mypy==1.7.1
 pytest==7.4.3
-pytest-asyncio==0.21.1
+pytest-asyncio==0.23.2
 pytest-cov==4.1.0
 
 uvicorn[standard]==0.23.2

--- a/apps/api/setup.cfg
+++ b/apps/api/setup.cfg
@@ -1,0 +1,3 @@
+[flake8]
+max-line-length = 88
+extend-ignore = E203


### PR DESCRIPTION
As we did before with last year's [HackUCI-Site](https://github.com/HackAtUCI/HackUCI-Site) repository, we can use a GitHub Actions workflow to run checks on pull requests and pushes to `main`.

The checks run for this pull request will initially fail because there is a type error in `saml.py` which will demonstrate that this runner works.

## Changes
- Include Python dev dependencies for checks runner
- Configure Python linting tools and provide compatible VS Code settings
- Update production deployment to run only when checks succeed