### PR TITLE
Update dependency versions in deployment workflows

### DIFF
--- a/.github/workflows/deploy-preview.yml
+++ b/.github/workflows/deploy-preview.yml
@@ -11,10 +11,10 @@ jobs:
     Site:
         runs-on: ubuntu-latest
         steps:
-            - uses: actions/checkout@v2
+            - uses: actions/checkout@v4
             - uses: amondnet/vercel-action@v25
               with:
-                  vercel-version: 30.2.2
+                  vercel-version: 32.6.1
                   github-comment: |
                       <table>
                         <tr>
@@ -37,10 +37,10 @@ jobs:
     Studio:
         runs-on: ubuntu-latest
         steps:
-            - uses: actions/checkout@v2
+            - uses: actions/checkout@v4
             - uses: amondnet/vercel-action@v25
               with:
-                  vercel-version: 30.2.2
+                  vercel-version: 32.6.1
                   github-comment: |
                       <table>
                         <tr>

--- a/.github/workflows/deploy-prod.yml
+++ b/.github/workflows/deploy-prod.yml
@@ -17,10 +17,10 @@ jobs:
     Site:
         runs-on: ubuntu-latest
         steps:
-            - uses: actions/checkout@v2
+            - uses: actions/checkout@v4
             - uses: amondnet/vercel-action@v25
               with:
-                  vercel-version: 30.2.2
+                  vercel-version: 32.6.1
                   github-comment: false
                   vercel-args: "--prod"
                   vercel-token: ${{ secrets.VERCEL_TOKEN }}
@@ -29,10 +29,10 @@ jobs:
     Studio:
         runs-on: ubuntu-latest
         steps:
-            - uses: actions/checkout@v2
+            - uses: actions/checkout@v4
             - uses: amondnet/vercel-action@v25
               with:
-                  vercel-version: 30.2.2
+                  vercel-version: 32.6.1
                   github-comment: false
                   vercel-args: "--prod"
                   vercel-token: ${{ secrets.VERCEL_TOKEN }}


### PR DESCRIPTION
Actions workflows indicated deprecation notice
> The following actions uses node12 which is deprecated and will be forced to run on node16: actions/checkout@v2. For more info: [GitHub Actions: All Actions will run on Node16 instead of Node12 by default](https://github.blog/changelog/2023-06-13-github-actions-all-actions-will-run-on-node16-instead-of-node12-by-default/)

## Changes
- Use actions/checkout@v4 and Vercel version 32.6.1