### PR TITLE
Integrate MongoDB Database

### DIFF
--- a/apps/api/Dockerfile
+++ b/apps/api/Dockerfile
@@ -1,11 +1,14 @@
 FROM python:3.9
 
-COPY requirements.txt requirements.txt
-
 RUN apt-get update && apt-get install -y libxml2-dev libxmlsec1-dev libxmlsec1-openssl
+
+WORKDIR /app
+
+COPY requirements.txt .
+
 RUN pip install --no-cache-dir -r requirements.txt "uvicorn[standard]"
 
-COPY src/ src/
+COPY src/ .
 
 ENV PYTHONPATH=src/
 

--- a/apps/api/Dockerfile
+++ b/apps/api/Dockerfile
@@ -1,9 +1,12 @@
 FROM python:3.9
 
-COPY . .
+COPY requirements.txt requirements.txt
 
-RUN apt-get update && apt-get upgrade -y
-RUN apt-get install -y pkg-config libxml2-dev libxmlsec1-dev libxmlsec1-openssl
-RUN pip install -r requirements.txt -r requirements-dev.txt
+RUN apt-get update && apt-get install -y libxml2-dev libxmlsec1-dev libxmlsec1-openssl
+RUN pip install --no-cache-dir -r requirements.txt "uvicorn[standard]"
+
+EXPOSE 8000
+
+COPY . .
 
 CMD ["python3", "src/dev.py"]

--- a/apps/api/Dockerfile
+++ b/apps/api/Dockerfile
@@ -7,6 +7,6 @@ RUN pip install --no-cache-dir -r requirements.txt "uvicorn[standard]"
 
 EXPOSE 8000
 
-COPY . .
+COPY src/ src/
 
 CMD ["python3", "src/dev.py"]

--- a/apps/api/Dockerfile
+++ b/apps/api/Dockerfile
@@ -9,4 +9,6 @@ EXPOSE 8000
 
 COPY src/ src/
 
-CMD ["python3", "src/dev.py"]
+ENV PYTHONPATH=src/
+
+CMD ["uvicorn", "app:app", "--host", "0.0.0.0"]

--- a/apps/api/Dockerfile
+++ b/apps/api/Dockerfile
@@ -1,0 +1,9 @@
+FROM python:3.9
+
+COPY . .
+
+RUN apt-get update && apt-get upgrade -y
+RUN apt-get install -y pkg-config libxml2-dev libxmlsec1-dev libxmlsec1-openssl
+RUN pip install -r requirements.txt -r requirements-dev.txt
+
+CMD ["python3", "src/dev.py"]

--- a/apps/api/Dockerfile
+++ b/apps/api/Dockerfile
@@ -5,8 +5,6 @@ COPY requirements.txt requirements.txt
 RUN apt-get update && apt-get install -y libxml2-dev libxmlsec1-dev libxmlsec1-openssl
 RUN pip install --no-cache-dir -r requirements.txt "uvicorn[standard]"
 
-EXPOSE 8000
-
 COPY src/ src/
 
 ENV PYTHONPATH=src/

--- a/apps/api/docker-compose.yml
+++ b/apps/api/docker-compose.yml
@@ -1,0 +1,31 @@
+# Use root/example as user/password credentials
+version: "3.1"
+
+services:
+    mongo:
+        image: mongo
+        restart: always
+        ports:
+            - "27017:27017"
+        environment:
+            MONGO_INITDB_ROOT_USERNAME: root
+            MONGO_INITDB_ROOT_PASSWORD: example
+
+    mongo-express:
+        image: mongo-express
+        restart: always
+        ports:
+            - "8081:8081"
+        environment:
+            ME_CONFIG_MONGODB_ADMINUSERNAME: root
+            ME_CONFIG_MONGODB_ADMINPASSWORD: example
+
+            ME_CONFIG_MONGODB_URL: mongodb://root:example@mongo:27017/
+
+    fastapi-dev:
+        network_mode: host
+        build: .
+        ports:
+            - "8000:8000"
+        environment:
+            MONGODB_URI: mongodb://root:example@127.0.0.1:27017

--- a/apps/api/docker-compose.yml
+++ b/apps/api/docker-compose.yml
@@ -5,8 +5,6 @@ services:
     mongo:
         image: mongo
         restart: always
-        ports:
-            - "27017:27017"
         environment:
             MONGO_INITDB_ROOT_USERNAME: root
             MONGO_INITDB_ROOT_PASSWORD: example
@@ -19,13 +17,11 @@ services:
         environment:
             ME_CONFIG_MONGODB_ADMINUSERNAME: root
             ME_CONFIG_MONGODB_ADMINPASSWORD: example
-
             ME_CONFIG_MONGODB_URL: mongodb://root:example@mongo:27017/
 
     fastapi-dev:
-        network_mode: host
         build: .
         ports:
             - "8000:8000"
         environment:
-            MONGODB_URI: mongodb://root:example@127.0.0.1:27017
+            MONGODB_URI: mongodb://root:example@mongo:27017

--- a/apps/api/docker-compose.yml
+++ b/apps/api/docker-compose.yml
@@ -8,6 +8,8 @@ services:
         environment:
             MONGO_INITDB_ROOT_USERNAME: root
             MONGO_INITDB_ROOT_PASSWORD: example
+        volumes:
+            - mongodb_data_volume:/data/db
 
     mongo-express:
         image: mongo-express
@@ -25,3 +27,6 @@ services:
             - "8000:8000"
         environment:
             MONGODB_URI: mongodb://root:example@mongo:27017
+
+volumes:
+    mongodb_data_volume:

--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -2,7 +2,7 @@
 	"name": "api",
 	"private": true,
 	"scripts": {
-		"dev": "docker compose up --no-deps --build",
+		"dev": "./run-docker.sh",
 		"test": "pytest",
 		"lint": "flake8 src tests && mypy src tests",
 		"format:write": "black src tests",

--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -2,7 +2,7 @@
 	"name": "api",
 	"private": true,
 	"scripts": {
-		"dev": "python src/dev.py",
+		"dev": "docker compose up --no-deps --build",
 		"test": "pytest",
 		"lint": "flake8 src tests && mypy src tests",
 		"format:write": "black src tests",

--- a/apps/api/requirements.txt
+++ b/apps/api/requirements.txt
@@ -2,3 +2,6 @@ fastapi==0.104.1
 httpx==0.25.2
 python-multipart==0.0.5
 python3-saml==1.16.0
+pymongo==4.6.1
+motor==3.3.2
+pydantic[email]==2.5.2

--- a/apps/api/requirements.txt
+++ b/apps/api/requirements.txt
@@ -2,6 +2,5 @@ fastapi==0.104.1
 httpx==0.25.2
 python-multipart==0.0.5
 python3-saml==1.16.0
-pymongo==4.6.1
 motor==3.3.2
 pydantic[email]==2.5.2

--- a/apps/api/run-docker.sh
+++ b/apps/api/run-docker.sh
@@ -1,0 +1,2 @@
+docker compose up
+docker compose down

--- a/apps/api/run-docker.sh
+++ b/apps/api/run-docker.sh
@@ -1,2 +1,2 @@
-docker compose up
+docker compose up --build
 docker compose down

--- a/apps/api/src/app.py
+++ b/apps/api/src/app.py
@@ -1,10 +1,11 @@
 from fastapi import FastAPI
 
-from routers import saml
+from routers import saml, demo
 
 app = FastAPI()
 
 app.include_router(saml.router, prefix="/saml", tags=["saml"])
+app.include_router(demo.router, prefix="/demo", tags=["demo"])
 
 
 @app.get("/")

--- a/apps/api/src/dev.py
+++ b/apps/api/src/dev.py
@@ -3,7 +3,7 @@ import uvicorn
 if __name__ == "__main__":
     uvicorn.run(
         "app:app",
-        host="localhost",
+        host="0.0.0.0",
         log_level="info",
         access_log=True,
         use_colors=True,

--- a/apps/api/src/dev.py
+++ b/apps/api/src/dev.py
@@ -3,7 +3,7 @@ import uvicorn
 if __name__ == "__main__":
     uvicorn.run(
         "app:app",
-        host="0.0.0.0",
+        host="localhost",
         log_level="info",
         access_log=True,
         use_colors=True,

--- a/apps/api/src/routers/demo.py
+++ b/apps/api/src/routers/demo.py
@@ -1,4 +1,4 @@
-from typing import Annotated, Union, Optional, Any
+from typing import Annotated, Union, Any
 
 from fastapi import APIRouter, Cookie, Form
 
@@ -20,10 +20,12 @@ async def square(value: Annotated[int, Form()]) -> int:
 
 
 @router.post("/user")
-async def get_user(name: Annotated[str, Form()]) -> list[dict[str, Any]]:
-    results = await retrieve(Collection.USERS, {"name": name}, ["name", "ucinetid"])
-    for i in range(len(results)):
-        results[i]["_id"] = str(results[i]["_id"])
+async def get_user(search_name: Annotated[str, Form()]) -> list[dict[str, object]]:
+    results = await retrieve(
+        Collection.USERS, {"name": search_name}, ["name", "ucinetid"]
+    )
+    for result in results:
+        result["_id"] = str(result["_id"])
     return results
 
 

--- a/apps/api/src/routers/demo.py
+++ b/apps/api/src/routers/demo.py
@@ -1,6 +1,8 @@
-from typing import Annotated, Union
+from typing import Annotated, Union, Optional, Any
 
 from fastapi import APIRouter, Cookie, Form
+
+from services.mongodb_handler import insert, retrieve, Collection
 
 router = APIRouter()
 
@@ -15,3 +17,18 @@ async def me(username: Annotated[Union[str, None], Cookie()] = None) -> str:
 async def square(value: Annotated[int, Form()]) -> int:
     """Calculate the square of the value."""
     return value * value
+
+
+@router.post("/user")
+async def get_user(name: Annotated[str, Form()]) -> list[dict[str, Any]]:
+    results = await retrieve(Collection.USERS, {"name": name}, ["name", "ucinetid"])
+    for i in range(len(results)):
+        results[i]["_id"] = str(results[i]["_id"])
+    return results
+
+
+@router.post("/add-user")
+async def add_user(
+    name: Annotated[str, Form()], ucinetid: Annotated[str, Form()]
+) -> Union[str, bool]:
+    return str(await insert(Collection.USERS, {"name": name, "ucinetid": ucinetid}))

--- a/apps/api/src/routers/demo.py
+++ b/apps/api/src/routers/demo.py
@@ -1,4 +1,4 @@
-from typing import Annotated, Union, Any
+from typing import Annotated, Union
 
 from fastapi import APIRouter, Cookie, Form
 
@@ -19,8 +19,8 @@ async def square(value: Annotated[int, Form()]) -> int:
     return value * value
 
 
-@router.post("/user")
-async def get_user(search_name: Annotated[str, Form()]) -> list[dict[str, object]]:
+@router.get("/user")
+async def get_user(search_name: str) -> list[dict[str, object]]:
     results = await retrieve(
         Collection.USERS, {"name": search_name}, ["name", "ucinetid"]
     )

--- a/apps/api/src/services/mongodb_handler.py
+++ b/apps/api/src/services/mongodb_handler.py
@@ -16,7 +16,6 @@ STAGING_ENV = os.getenv("DEPLOYMENT") == "STAGING"
 
 MONGODB_URI = os.getenv("MONGODB_URI")
 MONGODB_CLIENT = AsyncIOMotorClient(MONGODB_URI)
-MONGODB_CLIENT.get_io_loop = asyncio.get_event_loop
 
 DATABASE_NAME = "irvinehacks" if STAGING_ENV else "irvinehacks-prod"
 DB: AgnosticDatabase = MONGODB_CLIENT[DATABASE_NAME].with_options(

--- a/apps/api/src/services/mongodb_handler.py
+++ b/apps/api/src/services/mongodb_handler.py
@@ -1,0 +1,124 @@
+import asyncio
+import os
+from enum import Enum
+from logging import getLogger
+
+from typing import Any, Mapping, Optional, Union
+
+from bson import CodecOptions
+from motor.core import AgnosticCollection, AgnosticDatabase
+from motor.motor_asyncio import AsyncIOMotorClient
+from pydantic import BaseModel, Field
+from pymongo.results import InsertOneResult, UpdateResult
+
+log = getLogger(__name__)
+
+STAGING_ENV = os.getenv("DEPLOYMENT") == "STAGING"
+
+MONGODB_URI = os.getenv("MONGODB_URI")
+MONGODB_CLIENT = AsyncIOMotorClient(MONGODB_URI)
+MONGODB_CLIENT.get_io_loop = asyncio.get_event_loop
+
+DATABASE_NAME = "irvinehacks" if STAGING_ENV else "irvinehacks-prod"
+DB: AgnosticDatabase = MONGODB_CLIENT[DATABASE_NAME].with_options(
+    codec_options=CodecOptions(tz_aware=True)
+)
+
+
+class BaseRecord(BaseModel):
+    uid: str = Field(alias="_id")
+
+    def dict(self, *args: Any, **kwargs: Any) -> dict[str, Any]:
+        if "by_alias" in kwargs:
+            return BaseModel.model_dump(self, *args, **kwargs)
+        return BaseModel.model_dump(self, by_alias=True, *args, **kwargs)
+
+    class Config:
+        populate_by_name = True
+
+
+class Collection(str, Enum):
+    USERS = "users"
+    TESTING = "testing"
+
+    SETTINGS = "settings"
+
+
+async def insert(
+    collection: Collection, data: Mapping[str, object]
+) -> Union[str, bool]:
+    """Insert a document into the specified collection of the database"""
+    COLLECTION: AgnosticCollection = DB[collection.value]
+    result: InsertOneResult = await COLLECTION.insert_one(data)
+    if not result.acknowledged:
+        log.error("MongoDB document insertion was not acknowledged")
+        raise RuntimeError("Could not insert document into MongoDB collection")
+    new_document_id: str = result.inserted_id
+    return new_document_id
+
+
+async def retrieve_one(
+    collection: Collection, query: Mapping[str, object], fields: list[str] = []
+) -> Optional[dict[str, Any]]:
+    """Search for and retrieve the specified fields of all documents (if any exist)
+    that satisfy the provided query."""
+    COLLECTION = DB[collection.value]
+
+    result: Optional[dict[str, object]] = await COLLECTION.find_one(query, fields)
+    return result
+
+
+async def retrieve(
+    collection: Collection, query: Mapping[str, object], fields: list[str] = []
+) -> list[dict[str, object]]:
+    """Search for and retrieve the specified fields of a document (if any exist)
+    that satisfy the provided query."""
+
+    COLLECTION = DB[collection.value]
+
+    result = COLLECTION.find(query, fields)
+    output: list[dict[str, object]] = await result.to_list(length=None)
+
+    return output
+
+
+async def update_one(
+    collection: Collection,
+    query: Mapping[str, object],
+    new_data: Mapping[str, object],
+    *,
+    upsert: bool = False,
+) -> bool:
+    """Search for and set a document's fields using the provided query and data."""
+    return await raw_update_one(collection, query, {"$set": new_data}, upsert=upsert)
+
+
+async def raw_update_one(
+    collection: Collection,
+    query: Mapping[str, object],
+    update: Mapping[str, object],
+    *,
+    upsert: bool = False,
+) -> bool:
+    """Search for and update a document using the provided query and raw update."""
+    COLLECTION = DB[collection.value]
+    result: UpdateResult = await COLLECTION.update_one(query, update, upsert=upsert)
+    if not result.acknowledged:
+        log.error("MongoDB document update was not acknowledged")
+
+        raise RuntimeError("Could not update documents in MongoDB collection")
+
+    return result.modified_count > 0
+
+
+async def update(
+    collection: Collection, query: Mapping[str, object], new_data: Mapping[str, object]
+) -> bool:
+    """Search for and update documents (if they exist) using the provided query data."""
+    COLLECTION = DB[collection.value]
+    result: UpdateResult = await COLLECTION.update_many(query, {"$set": new_data})
+    if not result.acknowledged:
+        log.error("MongoDB document update was not acknowledged")
+        raise RuntimeError("Could not update documents in MongoDB collection")
+
+    return result.modified_count > 0

--- a/apps/api/src/services/mongodb_handler.py
+++ b/apps/api/src/services/mongodb_handler.py
@@ -2,7 +2,6 @@ import asyncio
 import os
 from enum import Enum
 from logging import getLogger
-
 from typing import Any, Mapping, Optional, Union
 
 from bson import CodecOptions
@@ -40,7 +39,6 @@ class BaseRecord(BaseModel):
 class Collection(str, Enum):
     USERS = "users"
     TESTING = "testing"
-
     SETTINGS = "settings"
 
 
@@ -73,12 +71,10 @@ async def retrieve(
 ) -> list[dict[str, object]]:
     """Search for and retrieve the specified fields of a document (if any exist)
     that satisfy the provided query."""
-
     COLLECTION = DB[collection.value]
 
     result = COLLECTION.find(query, fields)
     output: list[dict[str, object]] = await result.to_list(length=None)
-
     return output
 
 
@@ -105,7 +101,6 @@ async def raw_update_one(
     result: UpdateResult = await COLLECTION.update_one(query, update, upsert=upsert)
     if not result.acknowledged:
         log.error("MongoDB document update was not acknowledged")
-
         raise RuntimeError("Could not update documents in MongoDB collection")
 
     return result.modified_count > 0

--- a/apps/api/src/services/mongodb_handler.py
+++ b/apps/api/src/services/mongodb_handler.py
@@ -14,7 +14,10 @@ log = getLogger(__name__)
 STAGING_ENV = os.getenv("DEPLOYMENT") == "STAGING"
 
 MONGODB_URI = os.getenv("MONGODB_URI")
-MONGODB_CLIENT: AgnosticClient[Mapping[str, object]] = AsyncIOMotorClient(MONGODB_URI)
+
+# Mypy thinks AgnosticClient is a generic type, but providing type parameters to it
+# raises a TypeError.
+MONGODB_CLIENT: AgnosticClient = AsyncIOMotorClient(MONGODB_URI)  # type: ignore
 
 # Resolve Vercel runtime issue
 MONGODB_CLIENT.get_io_loop = asyncio.get_event_loop  # type: ignore

--- a/apps/api/src/services/mongodb_handler.py
+++ b/apps/api/src/services/mongodb_handler.py
@@ -17,7 +17,7 @@ MONGODB_URI = os.getenv("MONGODB_URI")
 MONGODB_CLIENT: AgnosticClient[Mapping[str, object]] = AsyncIOMotorClient(MONGODB_URI)
 
 # Resolve Vercel runtime issue
-MONGODB_CLIENT.get_io_loop = asyncio.get_event_loop # type: ignore
+MONGODB_CLIENT.get_io_loop = asyncio.get_event_loop  # type: ignore
 
 DATABASE_NAME = "irvinehacks" if STAGING_ENV else "irvinehacks-prod"
 DB = MONGODB_CLIENT[DATABASE_NAME].with_options(

--- a/apps/api/src/services/mongodb_handler.py
+++ b/apps/api/src/services/mongodb_handler.py
@@ -1,4 +1,3 @@
-import asyncio
 import os
 from enum import Enum
 from logging import getLogger

--- a/apps/api/src/services/mongodb_handler.py
+++ b/apps/api/src/services/mongodb_handler.py
@@ -1,3 +1,4 @@
+import asyncio
 import os
 from enum import Enum
 from logging import getLogger
@@ -15,6 +16,7 @@ STAGING_ENV = os.getenv("DEPLOYMENT") == "STAGING"
 
 MONGODB_URI = os.getenv("MONGODB_URI")
 MONGODB_CLIENT = AsyncIOMotorClient(MONGODB_URI)
+MONGODB_CLIENT.get_io_loop = asyncio.get_event_loop
 
 DATABASE_NAME = "irvinehacks" if STAGING_ENV else "irvinehacks-prod"
 DB: AgnosticDatabase = MONGODB_CLIENT[DATABASE_NAME].with_options(

--- a/apps/api/src/services/mongodb_handler.py
+++ b/apps/api/src/services/mongodb_handler.py
@@ -7,7 +7,7 @@ from typing import Any, Mapping, Optional, Union
 from bson import CodecOptions
 from motor.core import AgnosticClient
 from motor.motor_asyncio import AsyncIOMotorClient
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, Field, ConfigDict
 
 log = getLogger(__name__)
 
@@ -29,15 +29,14 @@ DB = MONGODB_CLIENT[DATABASE_NAME].with_options(
 
 
 class BaseRecord(BaseModel):
+    model_config = ConfigDict(populate_by_name=True)
+
     uid: str = Field(alias="_id")
 
     def dict(self, *args: Any, **kwargs: Any) -> dict[str, Any]:
         if "by_alias" in kwargs:
             return BaseModel.model_dump(self, *args, **kwargs)
         return BaseModel.model_dump(self, by_alias=True, *args, **kwargs)
-
-    class Config:
-        populate_by_name = True
 
 
 class Collection(str, Enum):

--- a/apps/api/tests/test_mongodb_handler.py
+++ b/apps/api/tests/test_mongodb_handler.py
@@ -1,0 +1,166 @@
+from unittest.mock import AsyncMock, MagicMock, Mock, patch
+
+import pytest
+from pymongo.results import InsertOneResult, UpdateResult
+
+from services import mongodb_handler
+from services.mongodb_handler import Collection
+
+SAMPLE_DOCUMENT = {"_id": "my-id", "email": "hack@uci.edu"}
+
+
+@patch("services.mongodb_handler.DB")
+async def test_insert_document_success(mock_DB: MagicMock) -> None:
+    """Test that inserting a document successfully returns the document id"""
+    mock_collection = AsyncMock()
+    mock_collection.insert_one.return_value = InsertOneResult(
+        "my-id", acknowledged=True
+    )
+    mock_DB.__getitem__.return_value = mock_collection
+
+    data = {"_id": "my-id", "email": "hack@uci.edu"}
+    result = await mongodb_handler.insert(Collection.TESTING, data)
+
+    mock_collection.insert_one.assert_awaited_once_with(data)
+    assert result == "my-id"
+
+
+@patch("services.mongodb_handler.DB")
+async def test_insert_document_failure(mock_DB: MagicMock) -> None:
+    """Test that a lack of write acknowledgement of insertion causes a RuntimeError"""
+    mock_collection = AsyncMock()
+    mock_collection.insert_one.return_value = InsertOneResult("", acknowledged=False)
+    mock_DB.__getitem__.return_value = mock_collection
+
+    data = {"_id": "my-id", "email": "hack@uci.edu"}
+    with pytest.raises(RuntimeError):
+        await mongodb_handler.insert(Collection.TESTING, data)
+        mock_collection.insert_one.assert_awaited_once_with(data)
+
+
+@patch("services.mongodb_handler.DB")
+async def test_retrieve_one_existing_document(mock_DB: MagicMock) -> None:
+    """Test that single existing document can be retrieved"""
+    mock_collection = AsyncMock()
+    mock_collection.find_one.return_value = SAMPLE_DOCUMENT
+    mock_DB.__getitem__.return_value = mock_collection
+
+    query = {"_id": "my-id"}
+    result = await mongodb_handler.retrieve_one(Collection.TESTING, query)
+    mock_collection.find_one.assert_awaited_once_with(query, [])
+    assert result == SAMPLE_DOCUMENT
+
+
+@patch("services.mongodb_handler.DB")
+async def test_retrieve_existing_documents(mock_DB: MagicMock) -> None:
+    """Test that multiple existing documents can be retrieved"""
+    SAMPLE_DOCUMENTS = [
+        {"_id": 0, "role": "hacker"},
+        {"_id": 1, "role": "hacker"},
+    ]
+
+    mock_collection = Mock()
+    mock_cursor = AsyncMock()
+    mock_cursor.to_list.return_value = SAMPLE_DOCUMENTS
+    mock_collection.find.return_value = mock_cursor
+    mock_DB.__getitem__.return_value = mock_collection
+
+    query = {"role": "hacker"}
+    result = await mongodb_handler.retrieve(Collection.TESTING, query)
+    mock_collection.find.assert_called_once_with(query, [])
+    assert result == SAMPLE_DOCUMENTS
+
+
+@patch("services.mongodb_handler.DB")
+async def test_update_existing_document(mock_DB: MagicMock) -> None:
+    """Test that single existing document can be updated"""
+    mock_collection = AsyncMock()
+    mock_collection.update_one.return_value = UpdateResult(
+        {
+            "n": 1,
+            "nModified": 1,
+        },
+        True,
+    )
+    mock_DB.__getitem__.return_value = mock_collection
+
+    query = {"_id": "my-id"}
+    update = {"name": "hack"}
+    result = await mongodb_handler.update_one(Collection.TESTING, query, update)
+    mock_collection.update_one.assert_awaited_once_with(
+        query, {"$set": update}, upsert=False
+    )
+    assert result is True
+
+
+@patch("services.mongodb_handler.DB")
+async def test_upsert_existing_document(mock_DB: MagicMock) -> None:
+    """Test that single existing document can be upserted"""
+    mock_collection = AsyncMock()
+    mock_collection.update_one.return_value = UpdateResult(
+        {
+            "n": 1,
+            "nModified": 1,
+        },
+        True,
+    )
+    mock_DB.__getitem__.return_value = mock_collection
+
+    query = {"_id": "my-id"}
+    update = {"status": "accepted"}
+    result = await mongodb_handler.update_one(
+        Collection.TESTING, query, update, upsert=True
+    )
+    mock_collection.update_one.assert_awaited_once_with(
+        query, {"$set": update}, upsert=True
+    )
+    assert result is True
+
+
+@patch("services.mongodb_handler.DB")
+async def test_update_existing_document_failure(mock_DB: MagicMock) -> None:
+    """Test that lack of acknowledgement during update causes RuntimeError"""
+    mock_collection = AsyncMock()
+    mock_collection.update_one.return_value = UpdateResult(dict(), False)
+    mock_DB.__getitem__.return_value = mock_collection
+
+    with pytest.raises(RuntimeError):
+        query = {"_id": "my-id"}
+        await mongodb_handler.update_one(Collection.TESTING, query, {"name": "hack"})
+        mock_collection.update_one.assert_awaited_once_with(
+            query, {"$set": {"name": "hack"}}
+        )
+
+
+@patch("services.mongodb_handler.DB")
+async def test_update_existing_documents(mock_DB: MagicMock) -> None:
+    """Test that multiple existing documents can be updated"""
+    mock_collection = AsyncMock()
+    mock_collection.update_many.return_value = UpdateResult(
+        {
+            "n": 20,
+            "nModified": 20,
+        },
+        True,
+    )
+    mock_DB.__getitem__.return_value = mock_collection
+
+    query = {"_id": "my-id"}
+    update = {"role": "hacker"}
+    result = await mongodb_handler.update(Collection.TESTING, query, update)
+    mock_collection.update_many.assert_awaited_once_with(query, {"$set": update})
+    assert result is True
+
+
+@patch("services.mongodb_handler.DB")
+async def test_update_existing_documents_failure(mock_DB: MagicMock) -> None:
+    """Test that lack of acknowledgement during update causes RuntimeError"""
+    mock_collection = AsyncMock()
+    mock_collection.update_many.return_value = UpdateResult(dict(), False)
+    mock_DB.__getitem__.return_value = mock_collection
+
+    update = {"role": "hacker"}
+    with pytest.raises(RuntimeError):
+        query = {"_id": "my-id"}
+        await mongodb_handler.update(Collection.TESTING, query, update)
+        mock_collection.update_many.assert_awaited_once_with(query, {"$set": update})

--- a/apps/site/src/app/demo/Demo.tsx
+++ b/apps/site/src/app/demo/Demo.tsx
@@ -10,8 +10,34 @@ async function Demo() {
 	return (
 		<div>
 			<p>Demo: {message}</p>
-			<form method="post" action="/api/demo/square">
-				<input type="number" required name="value" style={{ color: "black" }} />
+			<form method="post" action="/api/demo/user" className="mb-10">
+				<input
+					type="text"
+					required
+					id="name"
+					name="name"
+					style={{ color: "black" }}
+				/>
+				<br />
+				<button type="submit">Search Name</button>
+			</form>
+			<form method="post" action="/api/demo/add-user">
+				<input
+					type="text"
+					required
+					name="name"
+					style={{ color: "black" }}
+				/>
+				<br />
+				<br />
+				<input
+					type="text"
+					required
+					name="ucinetid"
+					style={{ color: "black" }}
+				/>
+				<br />
+				<br />
 				<button type="submit">Submit</button>
 			</form>
 		</div>

--- a/apps/site/src/app/demo/Demo.tsx
+++ b/apps/site/src/app/demo/Demo.tsx
@@ -10,12 +10,12 @@ async function Demo() {
 	return (
 		<div>
 			<p>Demo: {message}</p>
-			<form method="post" action="/api/demo/user" className="mb-10">
+			<form action="/api/demo/user" className="mb-10">
 				<input
 					type="text"
 					required
-					id="name"
-					name="name"
+					id="search_name"
+					name="search_name"
 					style={{ color: "black" }}
 				/>
 				<br />

--- a/apps/site/src/app/demo/page.tsx
+++ b/apps/site/src/app/demo/page.tsx
@@ -1,5 +1,1 @@
-import Demo from "./Demo";
-
-export default function DemoPage() {
-	return <Demo />;
-}
+export { default as Demo } from "./Demo";

--- a/apps/site/src/app/demo/page.tsx
+++ b/apps/site/src/app/demo/page.tsx
@@ -1,1 +1,1 @@
-export { default as Demo } from "./Demo";
+export { default as default } from "./Demo";

--- a/apps/site/src/app/demo/page.tsx
+++ b/apps/site/src/app/demo/page.tsx
@@ -1,0 +1,5 @@
+import Demo from "./Demo";
+
+export default function DemoPage() {
+	return <Demo />;
+}


### PR DESCRIPTION
# Overview
One of the challenges we faced last year was the inability to test database functions locally. This pull request resolves this issue by, as @taesungh suggested, using [Docker](https://docs.docker.com/get-docker/) to create an instance of MongoDB. Specifically, there is now a [Docker Compose](https://docs.docker.com/compose/) file that launches three containers: one that runs the backend, one that runs a MongoDB instance, and one that runs a user interface for the instance.

# Docker
For those of you who are unfamiliar with Docker, [Docker](https://www.docker.com/get-started/) is a tool that allows developers to deploy applications in sandbox environments known as containers. See our [Docker starter pack](https://github.com/HackAtUCI/starter-pack-docker) for an example on how Docker (and Docker Compose) can be used.

Note that Vercel [does not support](https://vercel.com/guides/does-vercel-support-docker-deployments) Docker deployments, so the database functions will be run on the cloud database using a non-production collection, not on your local machine. Thus, the Docker containers should only be run in your local environments.

# Setup
1. Firstly, please install [Docker](https://docs.docker.com/get-docker/). The process varies greatly depending on the operating system, so please refer to this article.
2. Next, open Docker Desktop.
3. Open a terminal or your editor and navigate to the project. Running `pnpm dev` should be all you need to get started!
    - You can access the aforementioned web interface for the database at `http://localhost:8081`. 

One of the cons of this approach is that hot reload is no longer possible because the Python files have been copied over to the Docker container. This means that stopping the container and rerunning `pnpm dev` is the best option.