### PR TITLE
Set up user identity and JWT for native users

### DIFF
--- a/apps/api/README.md
+++ b/apps/api/README.md
@@ -18,6 +18,7 @@ For deployment, the following environment variables need to be set:
 
 -   `PYTHONPATH=src/api` to properly import Python modules
 -   `SP_KEY`, the private key for SAML authentication
+-   `JWT_KEY`, the secret key used to sign JWTs
 -   `SENDGRID_API_KEY`, the API key needed to use the SendGrid API
 
 For staging, the following environment variables should also bet set:

--- a/apps/api/index.py
+++ b/apps/api/index.py
@@ -3,6 +3,10 @@ import logging
 from fastapi import FastAPI
 
 from app import app as api
+from auth.user_identity import JWT_SECRET
+
+if not JWT_SECRET:
+    raise RuntimeError("JWT_SECRET is not defined")
 
 # Override AWS Lambda logging configuration
 logging.basicConfig(level=logging.INFO, force=True)

--- a/apps/api/pyproject.toml
+++ b/apps/api/pyproject.toml
@@ -18,3 +18,9 @@ show_missing = true
 mypy_path = "src,stubs"
 explicit_package_bases = true
 strict = true
+plugins = ["pydantic.mypy"]
+
+[tool.pydantic-mypy]
+# init_forbid_extra = true
+init_typed = true
+warn_required_dynamic_aliases = true

--- a/apps/api/requirements-dev.txt
+++ b/apps/api/requirements-dev.txt
@@ -5,4 +5,6 @@ pytest==7.4.3
 pytest-asyncio==0.23.2
 pytest-cov==4.1.0
 
+types-python-jose==3.3.4.8
+
 uvicorn[standard]==0.23.2

--- a/apps/api/requirements.txt
+++ b/apps/api/requirements.txt
@@ -2,6 +2,7 @@ fastapi==0.104.1
 httpx==0.25.2
 python-multipart==0.0.5
 python3-saml==1.16.0
+python-jose[cryptography]==3.3.0
 motor==3.3.2
 pydantic[email]==2.5.2
 aiosendgrid==0.1.0

--- a/apps/api/src/app.py
+++ b/apps/api/src/app.py
@@ -1,11 +1,12 @@
 from fastapi import FastAPI
 
-from routers import saml, demo
+from routers import demo, saml, user
 
 app = FastAPI()
 
 app.include_router(saml.router, prefix="/saml", tags=["saml"])
 app.include_router(demo.router, prefix="/demo", tags=["demo"])
+app.include_router(user.router, prefix="/user", tags=["user"])
 
 
 @app.get("/")

--- a/apps/api/src/auth/user_identity.py
+++ b/apps/api/src/auth/user_identity.py
@@ -1,0 +1,156 @@
+import os
+from datetime import datetime, timedelta, timezone
+from typing import Any, Optional
+
+from fastapi import Cookie, HTTPException, Response, status
+from fastapi.testclient import TestClient
+from jose import JWTError, jwt
+from pydantic import BaseModel, EmailStr
+
+JWT_ALGORITHM = "HS256"
+JWT_SECRET = os.getenv("JWT_SECRET", "")
+
+
+class User(BaseModel):
+    uid: str
+    email: EmailStr
+
+    def __str__(self) -> str:
+        return self.uid
+
+
+class NativeUser(User):
+    ucinetid: str
+    display_name: str
+    affiliations: list[str]
+
+    def __init__(
+        self, *, ucinetid: str, display_name: str, email: str, affiliations: list[str]
+    ):
+        uid = f"edu.uci.{ucinetid}"
+        super().__init__(
+            uid=uid,
+            ucinetid=ucinetid,
+            display_name=display_name,
+            email=email,
+            affiliations=affiliations,
+        )
+
+
+class GuestUser(User):
+    def __init__(self, *, email: str):
+        uid = scoped_uid(EmailStr(email))
+        super().__init__(uid=uid, email=email)
+
+
+class UserTestClient(TestClient):
+    """Provide a test client that sends requests on behalf of the given user."""
+
+    def __init__(self, user: User, *args: Any, **kwargs: Any):
+        kwargs["cookies"] = kwargs.get("cookies", dict())
+        kwargs["cookies"]["hackuci_auth"] = _generate_jwt_token(user)
+        super().__init__(*args, **kwargs)
+
+
+class JWTClaims(BaseModel):
+    iat: datetime
+    exp: datetime
+    sub: str
+    data: dict[str, Any]
+
+
+def scoped_uid(email: EmailStr) -> str:
+    """Provide a scoped unique identifier based on the email domain."""
+    if uci_email(email):
+        raise ValueError("UCI user should use NativeUser")
+    local, domain = email.split("@")
+    reversed_domains = ".".join(reversed(domain.split(".")))
+    return f"{reversed_domains}.{local}"
+
+
+def uci_email(email: EmailStr) -> bool:
+    """Check whether or not an email address is part of UCI or a subdomain thereof."""
+    return email.endswith("@uci.edu") or email.endswith(".uci.edu")
+
+
+def utc_now() -> datetime:
+    """Return current datetime with proper UTC timezone."""
+    return datetime.now(timezone.utc)
+
+
+def remove_user_identity(response: Response) -> Response:
+    """Remove authentication cookie."""
+    response.set_cookie("hackuci_auth", "", max_age=0)
+    return response
+
+
+def issue_user_identity(user: User, response: Response) -> Response:
+    """Issue a user identity as a JWT cookie added to the given response."""
+    jwt_token = _generate_jwt_token(user)
+    response.set_cookie(
+        "hackuci_auth", jwt_token, max_age=4000, secure=True, httponly=True
+    )
+    return response
+
+
+def require_user_identity(hackuci_auth: Optional[str] = Cookie(None)) -> User:
+    """Provide the user decoded from the auth cookie.
+    Raise status 401 if valid identity cannot be decoded."""
+    user_identity = _decode_user_identity(hackuci_auth)
+    if not user_identity:
+        raise HTTPException(status.HTTP_401_UNAUTHORIZED, "Not authorized")
+
+    return user_identity
+
+
+def use_user_identity(hackuci_auth: Optional[str] = Cookie(None)) -> Optional[User]:
+    """Provide the user decoded from the auth cookie or `None` if invalid."""
+    return _decode_user_identity(hackuci_auth)
+
+
+def _decode_user_identity(user_token: Optional[str]) -> Optional[User]:
+    """Decode a user object from a JWT.
+    Return `None` if the token is empty or invalid."""
+    if not user_token:
+        return None
+
+    try:
+        decoded_token = _decode_jwt(user_token)
+    except ValueError:
+        return None
+
+    if decoded_token.sub.startswith("edu.uci."):
+        return NativeUser(**decoded_token.data)
+    return GuestUser(**decoded_token.data)
+
+
+def _generate_jwt_token(user: User) -> str:
+    """Generate a JWT with claims for the given user."""
+    if not JWT_SECRET:
+        raise RuntimeError("JWT_SECRET is not defined")
+
+    now = utc_now()
+
+    claims = JWTClaims(
+        iat=now,
+        exp=now + timedelta(hours=1),
+        sub=user.uid,
+        data=user.dict(exclude={"uid"}),
+    )
+
+    token = jwt.encode(claims.dict(), JWT_SECRET, algorithm=JWT_ALGORITHM)
+    return token
+
+
+def _decode_jwt(user_token: str) -> JWTClaims:
+    """Decode a JWT into its original claims.
+    Raise `ValueError` if the token is empty or invalid (including expired)."""
+    if not JWT_SECRET:
+        raise RuntimeError("JWT_SECRET is not defined")
+
+    try:
+        raw_claims = jwt.decode(user_token, JWT_SECRET, algorithms=[JWT_ALGORITHM])
+    except JWTError:
+        raise ValueError
+
+    return JWTClaims.parse_obj(raw_claims)

--- a/apps/api/src/auth/user_identity.py
+++ b/apps/api/src/auth/user_identity.py
@@ -30,7 +30,7 @@ class NativeUser(User):
         self, *, ucinetid: str, display_name: str, email: str, affiliations: list[str]
     ):
         uid = f"edu.uci.{ucinetid}"
-        super().__init__(  # type: ignore[call-arg]
+        super().__init__(
             uid=uid,
             ucinetid=ucinetid,
             display_name=display_name,

--- a/apps/api/src/auth/user_identity.py
+++ b/apps/api/src/auth/user_identity.py
@@ -1,6 +1,6 @@
 import os
 from datetime import datetime, timedelta, timezone
-from typing import Any, Optional
+from typing import Annotated, Any, Union
 
 from fastapi import Cookie, HTTPException, Response, status
 from fastapi.testclient import TestClient
@@ -96,7 +96,9 @@ def issue_user_identity(user: User, response: Response) -> Response:
     return response
 
 
-def require_user_identity(irvinehacks_auth: Optional[str] = Cookie(None)) -> User:
+def require_user_identity(
+    irvinehacks_auth: Annotated[Union[str, None], Cookie()] = None
+) -> User:
     """Provide the user decoded from the auth cookie.
     Raise status 401 if valid identity cannot be decoded."""
     user_identity = _decode_user_identity(irvinehacks_auth)
@@ -106,12 +108,14 @@ def require_user_identity(irvinehacks_auth: Optional[str] = Cookie(None)) -> Use
     return user_identity
 
 
-def use_user_identity(irvinehacks_auth: Optional[str] = Cookie(None)) -> Optional[User]:
+def use_user_identity(
+    irvinehacks_auth: Annotated[Union[str, None], Cookie()] = None
+) -> Union[User, None]:
     """Provide the user decoded from the auth cookie or `None` if invalid."""
     return _decode_user_identity(irvinehacks_auth)
 
 
-def _decode_user_identity(user_token: Optional[str]) -> Optional[User]:
+def _decode_user_identity(user_token: Union[str, None]) -> Union[User, None]:
     """Decode a user object from a JWT.
     Return `None` if the token is empty or invalid."""
     if not user_token:

--- a/apps/api/src/auth/user_identity.py
+++ b/apps/api/src/auth/user_identity.py
@@ -132,10 +132,10 @@ def _generate_jwt_token(user: User) -> str:
         iat=now,
         exp=now + timedelta(hours=1),
         sub=user.uid,
-        data=user.dict(exclude={"uid"}),
+        data=user.model_dump(exclude={"uid"}),
     )
 
-    token = jwt.encode(claims.dict(), JWT_SECRET, algorithm=JWT_ALGORITHM)
+    token = jwt.encode(claims.model_dump(), JWT_SECRET, algorithm=JWT_ALGORITHM)
     return token
 
 
@@ -147,4 +147,4 @@ def _decode_jwt(user_token: str) -> JWTClaims:
     except JWTError:
         raise ValueError
 
-    return JWTClaims.parse_obj(raw_claims)
+    return JWTClaims.model_validate(raw_claims)

--- a/apps/api/src/auth/user_identity.py
+++ b/apps/api/src/auth/user_identity.py
@@ -28,7 +28,7 @@ class NativeUser(User):
         self, *, ucinetid: str, display_name: str, email: str, affiliations: list[str]
     ):
         uid = f"edu.uci.{ucinetid}"
-        super().__init__(
+        super().__init__(  # type: ignore[call-arg]
             uid=uid,
             ucinetid=ucinetid,
             display_name=display_name,
@@ -39,7 +39,7 @@ class NativeUser(User):
 
 class GuestUser(User):
     def __init__(self, *, email: str):
-        uid = scoped_uid(EmailStr(email))
+        uid = scoped_uid(email)
         super().__init__(uid=uid, email=email)
 
 

--- a/apps/api/src/auth/user_identity.py
+++ b/apps/api/src/auth/user_identity.py
@@ -126,9 +126,6 @@ def _decode_user_identity(user_token: Optional[str]) -> Optional[User]:
 
 def _generate_jwt_token(user: User) -> str:
     """Generate a JWT with claims for the given user."""
-    if not JWT_SECRET:
-        raise RuntimeError("JWT_SECRET is not defined")
-
     now = utc_now()
 
     claims = JWTClaims(
@@ -145,9 +142,6 @@ def _generate_jwt_token(user: User) -> str:
 def _decode_jwt(user_token: str) -> JWTClaims:
     """Decode a JWT into its original claims.
     Raise `ValueError` if the token is empty or invalid (including expired)."""
-    if not JWT_SECRET:
-        raise RuntimeError("JWT_SECRET is not defined")
-
     try:
         raw_claims = jwt.decode(user_token, JWT_SECRET, algorithms=[JWT_ALGORITHM])
     except JWTError:

--- a/apps/api/src/auth/user_identity.py
+++ b/apps/api/src/auth/user_identity.py
@@ -65,7 +65,8 @@ def scoped_uid(email: EmailStr) -> str:
         raise ValueError("UCI user should use NativeUser")
     local, domain = email.split("@")
     reversed_domains = ".".join(reversed(domain.split(".")))
-    return f"{reversed_domains}.{local}"
+    cleaned_local = local.replace(".", "-")
+    return f"{reversed_domains}.{cleaned_local}"
 
 
 def uci_email(email: EmailStr) -> bool:

--- a/apps/api/src/routers/saml.py
+++ b/apps/api/src/routers/saml.py
@@ -10,7 +10,7 @@ from fastapi.responses import RedirectResponse, Response
 from onelogin.saml2.auth import OneLogin_Saml2_Auth
 from onelogin.saml2.settings import OneLogin_Saml2_Settings
 
-# from auth import user_identity
+from auth import user_identity
 
 log = getLogger(__name__)
 
@@ -91,7 +91,7 @@ async def login(req: Request) -> RedirectResponse:
 
 
 @router.post("/acs")
-async def acs(req: Request) -> str:
+async def acs(req: Request) -> RedirectResponse:
     """
     SAML Assertion Consumer Service.
     Accepts the response returned by the SAML Identity Provider and
@@ -119,16 +119,16 @@ async def acs(req: Request) -> str:
         log.exception("Error decoding SAML Attributes: %s", e)
         raise HTTPException(500, "Error decoding user identity")
 
-    # user = user_identity.NativeUser(
-    #     ucinetid=ucinetid,
-    #     display_name=display_name,
-    #     email=email,
-    #     affiliations=affiliations,
-    # )
+    user = user_identity.NativeUser(
+        ucinetid=ucinetid,
+        display_name=display_name,
+        email=email,
+        affiliations=affiliations,
+    )
 
-    # res = RedirectResponse("/", status_code=303)
-    # user_identity.issue_user_identity(user, res)
-    return f"Hello, {display_name} ({ucinetid})"
+    res = RedirectResponse("/", status_code=303)
+    user_identity.issue_user_identity(user, res)
+    return res
 
 
 @router.get("/sls")

--- a/apps/api/src/routers/user.py
+++ b/apps/api/src/routers/user.py
@@ -32,7 +32,7 @@ async def login(email: EmailStr = Form()) -> RedirectResponse:
 
 
 @router.get("/logout")
-async def log_out() -> RedirectResponse:
+async def logout() -> RedirectResponse:
     """Clear user identity cookie."""
     response = RedirectResponse("/", status.HTTP_303_SEE_OTHER)
     user_identity.remove_user_identity(response)

--- a/apps/api/src/routers/user.py
+++ b/apps/api/src/routers/user.py
@@ -1,0 +1,52 @@
+from logging import getLogger
+from typing import Optional
+
+from fastapi import APIRouter, Depends, Form, status
+from fastapi.responses import RedirectResponse
+from pydantic import BaseModel, EmailStr
+
+from auth import user_identity
+from auth.user_identity import User, use_user_identity
+from services import mongodb_handler
+from services.mongodb_handler import Collection
+from utils.user_record import Role
+
+log = getLogger(__name__)
+
+router = APIRouter()
+
+
+class IdentityResponse(BaseModel):
+    uid: Optional[str]
+    status: Optional[str]
+    role: Optional[Role]
+
+
+@router.post("/login")
+async def login(email: EmailStr = Form()) -> RedirectResponse:
+    log.info("%s requested to log in", email)
+    if user_identity.uci_email(email):
+        # redirect user to UCI SSO login endpoint, changing to GET method
+        return RedirectResponse("/api/saml/login", status.HTTP_303_SEE_OTHER)
+    return RedirectResponse("/api/guest/login", status.HTTP_307_TEMPORARY_REDIRECT)
+
+
+@router.get("/logout")
+async def log_out() -> RedirectResponse:
+    """Clear user identity cookie."""
+    response = RedirectResponse("/", status.HTTP_303_SEE_OTHER)
+    user_identity.remove_user_identity(response)
+    return response
+
+
+@router.get("/me", response_model=IdentityResponse)
+async def me(user: User = Depends(use_user_identity)) -> dict[str, object]:
+    log.info(user)
+    if not user:
+        return dict()
+    user_record = await mongodb_handler.retrieve_one(
+        Collection.USERS, {"_id": user.uid}
+    )
+    if not user_record:
+        return {"uid": user.uid}
+    return {**user_record, "uid": user.uid}

--- a/apps/api/src/routers/user.py
+++ b/apps/api/src/routers/user.py
@@ -17,9 +17,9 @@ router = APIRouter()
 
 
 class IdentityResponse(BaseModel):
-    uid: Union[str, None]
-    status: Union[str, None]
-    role: Union[Role, None]
+    uid: Union[str, None] = None
+    status: Union[str, None] = None
+    role: Union[Role, None] = None
 
 
 @router.post("/login")

--- a/apps/api/src/routers/user.py
+++ b/apps/api/src/routers/user.py
@@ -1,5 +1,5 @@
 from logging import getLogger
-from typing import Optional
+from typing import Annotated, Union
 
 from fastapi import APIRouter, Depends, Form, status
 from fastapi.responses import RedirectResponse
@@ -17,9 +17,9 @@ router = APIRouter()
 
 
 class IdentityResponse(BaseModel):
-    uid: Optional[str]
-    status: Optional[str]
-    role: Optional[Role]
+    uid: Union[str, None]
+    status: Union[str, None]
+    role: Union[Role, None]
 
 
 @router.post("/login")
@@ -40,7 +40,9 @@ async def log_out() -> RedirectResponse:
 
 
 @router.get("/me", response_model=IdentityResponse)
-async def me(user: User = Depends(use_user_identity)) -> dict[str, object]:
+async def me(
+    user: Annotated[Union[User, None], Depends(use_user_identity)]
+) -> dict[str, object]:
     log.info(user)
     if not user:
         return dict()

--- a/apps/api/src/utils/user_record.py
+++ b/apps/api/src/utils/user_record.py
@@ -1,0 +1,20 @@
+from enum import Enum
+
+from pydantic import Field
+
+from services.mongodb_handler import BaseRecord
+
+
+class Role(str, Enum):
+    APPLICANT = "applicant"
+    DIRECTOR = "director"
+    HACKER = "hacker"
+    MENTOR = "mentor"
+    REVIEWER = "reviewer"
+    TECH_ORGANIZER = "tech_organizer"
+    VOLUNTEER = "volunteer"
+
+
+class UserRecord(BaseRecord):
+    uid: str = Field(alias="_id")
+    role: Role

--- a/apps/api/tests/test_saml.py
+++ b/apps/api/tests/test_saml.py
@@ -53,9 +53,8 @@ def test_saml_acs_succeeds(mock_get_saml_auth: MagicMock) -> None:
     res = client.post("/acs", follow_redirects=False)
     mock_auth.process_response.assert_called()
 
-    assert res.text == '"Hello, Hack at UCI (hack)"'
     # check that user is redirected to main page
-    # assert res.status_code == 303
-    # assert res.headers["location"] == "/"
+    assert res.status_code == 303
+    assert res.headers["location"] == "/"
     # check that response sets appropriate cookie
-    # assert res.headers["Set-Cookie"].startswith("hackuci_auth=")
+    assert res.headers["Set-Cookie"].startswith("irvinehacks_auth=")

--- a/apps/api/tests/test_user.py
+++ b/apps/api/tests/test_user.py
@@ -1,0 +1,33 @@
+from fastapi import FastAPI, status
+from fastapi.testclient import TestClient
+
+from routers import user
+
+app = FastAPI()
+app.include_router(user.router)
+
+client = TestClient(app)
+
+
+def test_login_as_uci_redirects_to_saml() -> None:
+    """Tests that logging in with UCI email redirects to SAML for UCI SSO"""
+    res = client.post("/login", data={"email": "hack@uci.edu"}, follow_redirects=False)
+    assert res.status_code == status.HTTP_303_SEE_OTHER
+    assert res.headers["location"] == "/api/saml/login"
+
+
+def test_login_as_non_uci_redirects_to_guest_login() -> None:
+    """Test that logging in with a non-UCI email redirects to guest login endpoint."""
+    res = client.post(
+        "/login", data={"email": "jeff@amazon.com"}, follow_redirects=False
+    )
+    assert res.status_code == status.HTTP_307_TEMPORARY_REDIRECT
+    assert res.headers["location"] == "/api/guest/login"
+
+
+def test_logout() -> None:
+    """Test that logging out removes the authentication cookie."""
+    res = client.get("/logout", follow_redirects=False)
+    assert res.status_code == status.HTTP_303_SEE_OTHER
+    assert res.headers["location"] == "/"
+    assert res.headers["Set-Cookie"].startswith('hackuci_auth=""; Max-Age=0;')

--- a/apps/api/tests/test_user.py
+++ b/apps/api/tests/test_user.py
@@ -30,4 +30,4 @@ def test_logout() -> None:
     res = client.get("/logout", follow_redirects=False)
     assert res.status_code == status.HTTP_303_SEE_OTHER
     assert res.headers["location"] == "/"
-    assert res.headers["Set-Cookie"].startswith('hackuci_auth=""; Max-Age=0;')
+    assert res.headers["Set-Cookie"].startswith('irvinehacks_auth=""; Max-Age=0;')

--- a/apps/api/tests/test_user_identity.py
+++ b/apps/api/tests/test_user_identity.py
@@ -1,0 +1,77 @@
+from datetime import datetime
+from unittest.mock import Mock, patch
+
+import pytest
+from jose import JWTError
+
+from auth import user_identity
+from auth.user_identity import GuestUser, NativeUser
+
+
+def test_can_encode_and_decode_native_user() -> None:
+    """Test that a `NativeUser` can be encoded and decoded via JWT."""
+    ucinetid = "hack"
+    display_name = "Hack at UCI"
+    email = "hack@uci.edu"
+    affiliations = ["group"]
+
+    user = NativeUser(
+        ucinetid=ucinetid,
+        display_name=display_name,
+        email=email,
+        affiliations=affiliations,
+    )
+
+    jwt_token = user_identity._generate_jwt_token(user)
+    decoded_user = user_identity._decode_user_identity(jwt_token)
+
+    assert decoded_user == user
+
+
+def test_can_encode_and_decode_guest_user() -> None:
+    """Test that a `GuestUser` can be encoded and decoded via JWT."""
+    user = GuestUser(
+        email="hackuci@gmail.com",
+    )
+
+    jwt_token = user_identity._generate_jwt_token(user)
+    decoded_user = user_identity._decode_user_identity(jwt_token)
+
+    assert decoded_user == user
+
+
+def test_empty_identity_with_empty_token() -> None:
+    """Test that no identity is decoded from an empty token."""
+    user = user_identity._decode_user_identity(None)
+    assert user is None
+
+
+def test_error_on_invalid_token() -> None:
+    """Test that decoding an invalid token raises an exception."""
+    with pytest.raises(ValueError):
+        user_identity._decode_jwt("eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.e30.secret")
+
+
+@patch("auth.user_identity.datetime", autospec=True)
+def test_error_on_expired_token(mock_datetime: Mock) -> None:
+    """Test that decoding an expired token will cause a ValueError."""
+    # mock token creation time
+    mock_datetime.now.return_value = datetime(2014, 5, 23)
+
+    user = GuestUser(email="hackuci@gmail.com")
+    jwt_token = user_identity._generate_jwt_token(user)
+
+    mock_datetime.now.assert_called_once()
+    with pytest.raises(ValueError):
+        user_identity._decode_jwt(jwt_token)
+
+
+@patch("jose.jwt.decode", autospec=True)
+def test_jwt_error_causes_empty_identity(mock_jwt_decode: Mock) -> None:
+    """Test that decoding an expired token will cause a ValueError."""
+    user = GuestUser(email="hackuci@gmail.com")
+    mock_jwt_decode.side_effect = JWTError
+
+    jwt_token = user_identity._generate_jwt_token(user)
+    decoded_user = user_identity._decode_user_identity(jwt_token)
+    assert decoded_user is None

--- a/apps/api/tests/test_user_identity.py
+++ b/apps/api/tests/test_user_identity.py
@@ -40,6 +40,13 @@ def test_can_encode_and_decode_guest_user() -> None:
     assert decoded_user == user
 
 
+def test_scoped_uid_with_dots() -> None:
+    """Test scoped uid properly processes local and domain parts."""
+    assert user_identity.scoped_uid("kate@cc.edu") == "edu.cc.kate"
+    assert user_identity.scoped_uid("kate@student.cc.edu") == "edu.cc.student.kate"
+    assert user_identity.scoped_uid("student.kate@cc.edu") == "edu.cc.student-kate"
+
+
 def test_empty_identity_with_empty_token() -> None:
     """Test that no identity is decoded from an empty token."""
     user = user_identity._decode_user_identity(None)


### PR DESCRIPTION
Include the user identity code from last year to provide JWTs when completing SAML authentication.
The full guest authentication flow will come separately with #68, but the user identity foundation is provided here, e.g. the `GuestUser` model.

Closes #69.

## Changes
- Import user and user identity from last year
  - Import `user_identity` auth, `user` router, and `user_record` util, and associated tests from last year's [HackAtUCI/HackUCI-Site](https://github.com/HackAtUCI/HackUCI-Site)
  - Install [python-jose[cryptography]](https://github.com/mpdavis/python-jose)
  - Add user router to app
- Move `JWT_SECRET` check to `index.py`
- Resolve type errors w/ `NativeUser`, `EmailStr`
  - Ignore call-arg error when calling super constructor
  - `EmailStr` no longer needs to be explicitly constructed
- Resolve pydantic deprecation warnings
  - Replace `dict` with `model_dump` and `parse_obj` with `model_validate`
- Fix uid scoping when local part contains dot
- Incorporate user identity with SAML authentication
  - Provide user identity cookie when authenticating with SAML ACS
  - Rename `hackuci_auth` to `irvinehacks_auth`
- Improve type annotations in user/user_identity
  - Use `Annotated` for `Cookie` and `Union` instead of `Optional`
- Fix model issue with `IdentityResponse` for user
  - [`Optional` fields are no longer not required in Pydantic V2 models](https://docs.pydantic.dev/2.0/migration/#required-optional-and-nullable-fields)
  - Add unit test for `/user/me` endpoint
- Include note in API README about `JWT_KEY`
- Rename `log_out` to `logout` for consistency
- Add Pydantic mypy plugin to fix submodel call-arg

## Testing
Staging subdomain was manually assigned to the preview deployment. Confirmed SAML flow works and user identity cookie is provided which is properly consumed by `/api/user/me` endpoint.