### PR TITLE
Temporarily disable production deployment flag

### DIFF
--- a/.github/workflows/deploy-prod.yml
+++ b/.github/workflows/deploy-prod.yml
@@ -22,7 +22,7 @@ jobs:
               with:
                   vercel-version: 32.6.1
                   github-comment: false
-                  vercel-args: "--prod"
+                  #   vercel-args: "--prod"
                   vercel-token: ${{ secrets.VERCEL_TOKEN }}
                   vercel-org-id: ${{ vars.VERCEL_ORG_ID}}
                   vercel-project-id: ${{ vars.VERCEL_PROJECT_ID_SITE}}
@@ -34,7 +34,7 @@ jobs:
               with:
                   vercel-version: 32.6.1
                   github-comment: false
-                  vercel-args: "--prod"
+                  #   vercel-args: "--prod"
                   vercel-token: ${{ secrets.VERCEL_TOKEN }}
                   vercel-org-id: ${{ vars.VERCEL_ORG_ID}}
                   vercel-project-id: ${{ vars.VERCEL_PROJECT_ID_STUDIO}}


### PR DESCRIPTION
As part of #87
- Until we finish the application page and system, disable deployments to the production domain
- We will also need to manually assign the staging domain because Vercel still has not resolved our domain ownership issue