### PR TITLE
feat: UserContext implementation

### DIFF
--- a/apps/site/src/app/App.tsx
+++ b/apps/site/src/app/App.tsx
@@ -7,11 +7,13 @@ import { Layout } from "@/components/dom/Layout";
 import Footer from "@/lib/components/Footer/Footer";
 
 export default function App({ children }: { children: React.ReactNode }) {
-    return (
-        <UserContext.Provider value={{ uid: "test", role: "test", status: "test" }}>
-            <Navbar />
-            <Layout>{children}</Layout>
-            <Footer />
-        </UserContext.Provider>
-    )
+	return (
+		<UserContext.Provider
+			value={{ uid: "test", role: "test", status: "test" }}
+		>
+			<Navbar />
+			<Layout>{children}</Layout>
+			<Footer />
+		</UserContext.Provider>
+	);
 }

--- a/apps/site/src/app/App.tsx
+++ b/apps/site/src/app/App.tsx
@@ -1,0 +1,17 @@
+"use client";
+
+import React from "react";
+import UserContext from "@/lib/utils/userContext";
+import Navbar from "@/lib/components/Navbar/Navbar";
+import { Layout } from "@/components/dom/Layout";
+import Footer from "@/lib/components/Footer/Footer";
+
+export default function App({ children }: { children: React.ReactNode }) {
+    return (
+        <UserContext.Provider value={{ uid: "test", role: "test", status: "test" }}>
+            <Navbar />
+            <Layout>{children}</Layout>
+            <Footer />
+        </UserContext.Provider>
+    )
+}

--- a/apps/site/src/app/layout.tsx
+++ b/apps/site/src/app/layout.tsx
@@ -22,7 +22,7 @@ export default async function RootLayout({
 				}}
 				className="overflow-x-hidden bg-top bg-repeat-y bg-[length:100%]"
 			>
-				<App children={children} />
+				<App>{children}</App>
 			</body>
 		</html>
 	);

--- a/apps/site/src/app/layout.tsx
+++ b/apps/site/src/app/layout.tsx
@@ -1,10 +1,7 @@
 import type { Metadata } from "next";
 import water from "@/assets/backgrounds/water.jpg";
-import Footer from "@/lib/components/Footer/Footer";
+import App from "./App";
 import "./globals.css";
-
-import { Layout } from "@/components/dom/Layout";
-import Navbar from "@/lib/components/Navbar/Navbar";
 
 export const metadata: Metadata = {
 	title: "IrvineHacks 2024",
@@ -12,7 +9,7 @@ export const metadata: Metadata = {
 		"IrvineHacks is Hack at UCI's premier hackathon for collegiate students.",
 };
 
-export default function RootLayout({
+export default async function RootLayout({
 	children,
 }: {
 	children: React.ReactNode;
@@ -25,10 +22,7 @@ export default function RootLayout({
 				}}
 				className="overflow-x-hidden bg-top bg-repeat-y bg-[length:100%]"
 			>
-				{/* reference: https://github.com/pmndrs/react-three-next */}
-				<Navbar/>
-				<Layout>{children}</Layout>
-				<Footer />
+				<App children={children} />
 			</body>
 		</html>
 	);

--- a/apps/site/src/lib/utils/userContext.ts
+++ b/apps/site/src/lib/utils/userContext.ts
@@ -1,0 +1,15 @@
+import { createContext } from "react";
+
+const UserContext = createContext<Identity>({
+	uid: null,
+	role: null,
+	status: null,
+});
+
+export interface Identity {
+	uid: string | null;
+	role: string | null;
+	status: string | null;
+}
+
+export default UserContext;


### PR DESCRIPTION
Sets up the [UserContext](https://github.com/HackAtUCI/HackUCI-Site/blob/main/src/utils/userContext.tsx) from last year's website. Note that because the `Navbar` relies on this context, we need to use this context in `layout.tsx`, which essentially converts everything to a client component.