### PR TITLE
Run Sanity deploy preview only when PR is labeled

### DIFF
--- a/.github/workflows/deploy-preview.yml
+++ b/.github/workflows/deploy-preview.yml
@@ -36,6 +36,7 @@ jobs:
                   vercel-project-id: ${{ vars.VERCEL_PROJECT_ID_SITE}}
     Studio:
         runs-on: ubuntu-latest
+        if: contains(github.event.pull_request.labels.*.name, 'sanity')
         steps:
             - uses: actions/checkout@v4
             - uses: amondnet/vercel-action@v25


### PR DESCRIPTION
Resolves #106 since we are limited by Vercel's hobby tier limit on deployments per day. This will effectively reduce our usage by half.
- Run the Sanity preview deployment workflow only when the pull request is labeled with 'sanity'