### PR TITLE
Add `/user/apply` API endpoint to receive hacker applications

### DIFF
--- a/apps/api/src/models/ApplicationData.py
+++ b/apps/api/src/models/ApplicationData.py
@@ -2,7 +2,7 @@ from datetime import datetime
 from enum import Enum
 from typing import Union
 
-from pydantic import BaseModel, ConfigDict, Field, HttpUrl
+from pydantic import BaseModel, ConfigDict, Field, HttpUrl, field_serializer
 
 from .utils import form_body
 
@@ -39,3 +39,9 @@ class ProcessedApplicationData(RawApplicationData):
     resume_url: Union[HttpUrl, None] = None
     submission_time: datetime
     reviews: list[Review] = []
+
+    @field_serializer("linkedin", "portfolio", "resume_url")
+    def url2str(self, val: Union[HttpUrl, None]) -> Union[str, None]:
+        if val is not None:
+            return str(val)
+        return val

--- a/apps/api/src/models/ApplicationData.py
+++ b/apps/api/src/models/ApplicationData.py
@@ -30,13 +30,13 @@ class RawApplicationData(BaseModel):
     education_level: str
     major: str
     is_first_hackathon: bool
-    portfolio_link: Union[HttpUrl, None]
-    linkedin_link: Union[HttpUrl, None]
+    portfolio_link: Union[HttpUrl, None] = None
+    linkedin_link: Union[HttpUrl, None] = None
     collaboration_question: Union[str, None] = Field(None, max_length=1024)
     any_job_question: str = Field(max_length=1024)
 
 
 class ProcessedApplicationData(RawApplicationData):
-    resume_url: Union[HttpUrl, None]
+    resume_url: Union[HttpUrl, None] = None
     submission_time: datetime
     reviews: list[Review] = []

--- a/apps/api/src/models/ApplicationData.py
+++ b/apps/api/src/models/ApplicationData.py
@@ -2,7 +2,7 @@ from datetime import datetime
 from enum import Enum
 from typing import Union
 
-from pydantic import BaseModel, ConfigDict, EmailStr, Field, HttpUrl
+from pydantic import BaseModel, ConfigDict, Field, HttpUrl
 
 from .utils import form_body
 
@@ -22,18 +22,17 @@ class RawApplicationData(BaseModel):
 
     first_name: str
     last_name: str
-    email: EmailStr
     pronouns: str
     ethnicity: str
     is_18_older: bool
-    university: str
+    school: str
     education_level: str
     major: str
     is_first_hackathon: bool
-    portfolio_link: Union[HttpUrl, None] = None
-    linkedin_link: Union[HttpUrl, None] = None
-    collaboration_question: Union[str, None] = Field(None, max_length=1024)
-    any_job_question: str = Field(max_length=1024)
+    linkedin: Union[HttpUrl, None] = None
+    portfolio: Union[HttpUrl, None] = None
+    frq_collaboration: Union[str, None] = Field(None, max_length=1024)
+    frq_dream_job: str = Field(max_length=1024)
 
 
 class ProcessedApplicationData(RawApplicationData):

--- a/apps/api/src/routers/user.py
+++ b/apps/api/src/routers/user.py
@@ -12,7 +12,7 @@ from models.ApplicationData import ProcessedApplicationData, RawApplicationData
 from services import mongodb_handler
 from services.mongodb_handler import Collection
 from utils import email_handler, resume_handler
-from utils.user_record import Applicant, Role
+from utils.user_record import Applicant, Role, Status
 
 log = getLogger(__name__)
 
@@ -95,14 +95,14 @@ async def apply(
 
     now = datetime.now(timezone.utc)
     processed_application_data = ProcessedApplicationData(
-        **raw_application_data.dict(),
+        **raw_application_data.model_dump(),
         resume_url=resume_url,
         submission_time=now,
     )
     applicant = Applicant(
-        _id=user.uid,
+        uid=user.uid,
         application_data=processed_application_data,
-        status="PENDING_REVIEW",
+        status=Status.PENDING_REVIEW,
     )
 
     # add applicant to database
@@ -110,7 +110,7 @@ async def apply(
         await mongodb_handler.update_one(
             Collection.USERS,
             {"_id": user.uid},
-            applicant.dict(),
+            applicant.model_dump(),
             upsert=True,
         )
     except RuntimeError:

--- a/apps/api/src/routers/user.py
+++ b/apps/api/src/routers/user.py
@@ -119,7 +119,7 @@ async def apply(
 
     try:
         await email_handler.send_application_confirmation_email(
-            applicant.application_data
+            user.email, applicant.application_data
         )
     except RuntimeError:
         log.error("Could not send confirmation email with SendGrid to %s.", user.uid)

--- a/apps/api/src/routers/user.py
+++ b/apps/api/src/routers/user.py
@@ -59,8 +59,8 @@ async def me(
 
 @router.post("/apply", status_code=status.HTTP_201_CREATED)
 async def apply(
-    user: User = Depends(require_user_identity),
-    raw_application_data: RawApplicationData = Depends(RawApplicationData),
+    user: Annotated[User, Depends(require_user_identity)],
+    raw_application_data: Annotated[RawApplicationData, Depends(RawApplicationData)],
     resume: Optional[UploadFile] = None,
 ) -> None:
     # check if email is already in database

--- a/apps/api/src/routers/user.py
+++ b/apps/api/src/routers/user.py
@@ -1,15 +1,18 @@
+from datetime import datetime, timezone
 from logging import getLogger
-from typing import Annotated, Union
+from typing import Annotated, Optional, Union
 
-from fastapi import APIRouter, Depends, Form, status
+from fastapi import APIRouter, Depends, Form, HTTPException, UploadFile, status
 from fastapi.responses import RedirectResponse
 from pydantic import BaseModel, EmailStr
 
 from auth import user_identity
-from auth.user_identity import User, use_user_identity
+from auth.user_identity import User, require_user_identity, use_user_identity
+from models.ApplicationData import ProcessedApplicationData, RawApplicationData
 from services import mongodb_handler
 from services.mongodb_handler import Collection
-from utils.user_record import Role
+from utils import email_handler, resume_handler
+from utils.user_record import Applicant, Role
 
 log = getLogger(__name__)
 
@@ -52,3 +55,76 @@ async def me(
     if not user_record:
         return {"uid": user.uid}
     return {**user_record, "uid": user.uid}
+
+
+@router.post("/apply", status_code=status.HTTP_201_CREATED)
+async def apply(
+    user: User = Depends(require_user_identity),
+    raw_application_data: RawApplicationData = Depends(RawApplicationData),
+    resume: Optional[UploadFile] = None,
+) -> None:
+    # check if email is already in database
+    EXISTING_RECORD = await mongodb_handler.retrieve_one(
+        Collection.USERS, {"_id": user.uid}
+    )
+
+    if EXISTING_RECORD and "status" in EXISTING_RECORD:
+        log.error("User %s has already applied.", user)
+        raise HTTPException(status.HTTP_400_BAD_REQUEST)
+
+    if resume is not None:
+        try:
+            resume_url = await resume_handler.upload_resume(
+                raw_application_data, resume
+            )
+        except TypeError:
+            log.info("%s provided invalid resume type.", user)
+            raise HTTPException(
+                status.HTTP_415_UNSUPPORTED_MEDIA_TYPE, "Invalid resume file type"
+            )
+        except ValueError:
+            log.info("%s provided too large resume.", user)
+            raise HTTPException(
+                status.HTTP_413_REQUEST_ENTITY_TOO_LARGE, "Resume upload is too large"
+            )
+        except RuntimeError as err:
+            log.error("During user %s apply, resume upload: %s", user.uid, err)
+            raise HTTPException(status.HTTP_500_INTERNAL_SERVER_ERROR)
+    else:
+        resume_url = None
+
+    now = datetime.now(timezone.utc)
+    processed_application_data = ProcessedApplicationData(
+        **raw_application_data.dict(),
+        resume_url=resume_url,
+        submission_time=now,
+    )
+    applicant = Applicant(
+        _id=user.uid,
+        application_data=processed_application_data,
+        status="PENDING_REVIEW",
+    )
+
+    # add applicant to database
+    try:
+        await mongodb_handler.update_one(
+            Collection.USERS,
+            {"_id": user.uid},
+            applicant.dict(),
+            upsert=True,
+        )
+    except RuntimeError:
+        log.error("Could not insert applicant %s to MongoDB.", user.uid)
+        raise HTTPException(status.HTTP_500_INTERNAL_SERVER_ERROR)
+
+    try:
+        await email_handler.send_application_confirmation_email(
+            applicant.application_data
+        )
+    except RuntimeError:
+        log.error("Could not send confirmation email with SendGrid to %s.", user.uid)
+        raise HTTPException(status.HTTP_500_INTERNAL_SERVER_ERROR)
+
+    # TODO: handle inconsistent results if one service fails
+
+    log.info("%s submitted an application", user.uid)

--- a/apps/api/src/utils/email_handler.py
+++ b/apps/api/src/utils/email_handler.py
@@ -9,19 +9,20 @@ IH_SENDER = ("apply@irvinehacks.com", "IrvineHacks 2024 Applications")
 
 
 class ContactInfo(Protocol):
-    email: EmailStr
     first_name: str
     last_name: str
 
 
-async def send_application_confirmation_email(user: ContactInfo) -> None:
+async def send_application_confirmation_email(
+    email: EmailStr, user: ContactInfo
+) -> None:
     """Send a confirmation email after a user submits an application.
     Will propagate exceptions from SendGrid."""
     await sendgrid_handler.send_email(
         Template.CONFIRMATION_EMAIL,
         IH_SENDER,
         {
-            "email": user.email,
+            "email": email,
             "first_name": user.first_name,
             "last_name": user.last_name,
         },

--- a/apps/api/src/utils/resume_handler.py
+++ b/apps/api/src/utils/resume_handler.py
@@ -5,6 +5,7 @@ from typing import Protocol
 
 from aiogoogle import HTTPError
 from fastapi import UploadFile
+from pydantic import HttpUrl
 
 from services import gdrive_handler
 
@@ -20,7 +21,7 @@ class Person(Protocol):
     last_name: str
 
 
-async def upload_resume(person: Person, resume_upload: UploadFile) -> str:
+async def upload_resume(person: Person, resume_upload: UploadFile) -> HttpUrl:
     """Upload resume file to Google Drive and provide url to uploaded file.
     Reject files larger than size limit"""
     if not RESUMES_FOLDER_ID:
@@ -49,4 +50,4 @@ async def upload_resume(person: Person, resume_upload: UploadFile) -> str:
         log.error("During resume upload: %s", err)
         raise RuntimeError("Could not upload resume to Google Drive")
 
-    return resume_url
+    return HttpUrl(resume_url)

--- a/apps/api/src/utils/user_record.py
+++ b/apps/api/src/utils/user_record.py
@@ -1,7 +1,9 @@
 from enum import Enum
+from typing import Union
 
 from pydantic import Field
 
+from models.ApplicationData import Decision, ProcessedApplicationData
 from services.mongodb_handler import BaseRecord
 
 
@@ -15,6 +17,18 @@ class Role(str, Enum):
     VOLUNTEER = "volunteer"
 
 
+class Status(str, Enum):
+    PENDING_REVIEW = "PENDING_REVIEW"
+    REVIEWED = "REVIEWED"
+    CONFIRMED = "CONFIRMED"
+
+
 class UserRecord(BaseRecord):
     uid: str = Field(alias="_id")
     role: Role
+
+
+class Applicant(UserRecord):
+    role = Role.APPLICANT
+    status: Union[Status, Decision]
+    application_data: ProcessedApplicationData

--- a/apps/api/src/utils/user_record.py
+++ b/apps/api/src/utils/user_record.py
@@ -29,6 +29,6 @@ class UserRecord(BaseRecord):
 
 
 class Applicant(UserRecord):
-    role = Role.APPLICANT
+    role: Role = Role.APPLICANT
     status: Union[Status, Decision]
     application_data: ProcessedApplicationData

--- a/apps/api/tests/test_user_apply.py
+++ b/apps/api/tests/test_user_apply.py
@@ -3,6 +3,7 @@ from unittest.mock import AsyncMock, Mock, patch
 
 from aiogoogle import HTTPError
 from fastapi import FastAPI
+from pydantic import HttpUrl
 
 from auth.user_identity import NativeUser, UserTestClient
 from models.ApplicationData import ProcessedApplicationData
@@ -39,13 +40,13 @@ BAD_RESUME = ("bad-resume.doc", b"resume", "application/msword")
 LARGE_RESUME = ("large-resume.pdf", b"resume" * 100_000, "application/pdf")
 
 EXPECTED_RESUME_UPLOAD = ("pk-fire-69f2afc2.pdf", b"resume", "application/pdf")
-SAMPLE_RESUME_URL = "https://drive.google.com/file/d/..."
+SAMPLE_RESUME_URL = HttpUrl("https://drive.google.com/file/d/...")
 SAMPLE_SUBMISSION_TIME = datetime(2023, 1, 12, 8, 1, 21)
 SAMPLE_VERDICT_TIME = None
 
 EXPECTED_APPLICATION_DATA = ProcessedApplicationData(
     **SAMPLE_APPLICATION,  # type: ignore[arg-type]
-    resume_url=SAMPLE_RESUME_URL,  # type: ignore[arg-type]
+    resume_url=SAMPLE_RESUME_URL,
     submission_time=SAMPLE_SUBMISSION_TIME,
     verdict_time=SAMPLE_VERDICT_TIME,
 )

--- a/apps/api/tests/test_user_apply.py
+++ b/apps/api/tests/test_user_apply.py
@@ -1,6 +1,7 @@
 from datetime import datetime
 from unittest.mock import AsyncMock, Mock, patch
 
+import bson
 from aiogoogle import HTTPError
 from fastapi import FastAPI
 from pydantic import HttpUrl
@@ -29,6 +30,7 @@ SAMPLE_APPLICATION = {
     "education_level": "Fifth+ Year Undergraduate",
     "major": "Computer Science",
     "is_first_hackathon": "false",
+    "portfolio": "https://github.com",
     "frq_collaboration": "I am pkfire",
     "frq_dream_job": "I am pkfire",
 }
@@ -249,3 +251,11 @@ def test_apply_successfully_without_resume(
         EXPECTED_APPLICATION_DATA_WITHOUT_RESUME
     )
     assert res.status_code == 201
+
+
+def test_application_data_is_bson_encodable() -> None:
+    """Test that application data model can be encoded into BSON to store in MongoDB."""
+    data = EXPECTED_APPLICATION_DATA.model_copy()
+    data.linkedin = HttpUrl("https://linkedin.com")
+    encoded = bson.encode(EXPECTED_APPLICATION_DATA.model_dump())
+    assert len(encoded) == 415

--- a/apps/api/tests/test_user_apply.py
+++ b/apps/api/tests/test_user_apply.py
@@ -13,10 +13,11 @@ from services.mongodb_handler import Collection
 from utils import resume_handler
 from utils.user_record import Applicant, Status
 
+USER_EMAIL = "pkfire@uci.edu"
 USER_PKFIRE = NativeUser(
     ucinetid="pkfire",
     display_name="pkfire",
-    email="pkfire@uci.edu",
+    email=USER_EMAIL,
     affiliations=["pkfire"],
 )
 
@@ -107,7 +108,7 @@ def test_apply_successfully(
         upsert=True,
     )
     mock_send_application_confirmation_email.assert_awaited_once_with(
-        EXPECTED_APPLICATION_DATA
+        USER_EMAIL, EXPECTED_APPLICATION_DATA
     )
     assert res.status_code == 201
 
@@ -248,7 +249,7 @@ def test_apply_successfully_without_resume(
         upsert=True,
     )
     mock_send_application_confirmation_email.assert_awaited_once_with(
-        EXPECTED_APPLICATION_DATA_WITHOUT_RESUME
+        USER_EMAIL, EXPECTED_APPLICATION_DATA_WITHOUT_RESUME
     )
     assert res.status_code == 201
 

--- a/apps/api/tests/test_user_apply.py
+++ b/apps/api/tests/test_user_apply.py
@@ -1,0 +1,249 @@
+from datetime import datetime
+from unittest.mock import AsyncMock, Mock, patch
+
+from aiogoogle import HTTPError
+from fastapi import FastAPI
+
+from auth.user_identity import NativeUser, UserTestClient
+from models.ApplicationData import ProcessedApplicationData
+from routers import user
+from services.mongodb_handler import Collection
+from utils import resume_handler
+from utils.user_record import Applicant
+
+USER_PKFIRE = NativeUser(
+    ucinetid="pkfire",
+    display_name="pkfire",
+    email="pkfire@uci.edu",
+    affiliations=["pkfire"],
+)
+
+SAMPLE_APPLICATION = {
+    "first_name": "pk",
+    "last_name": "fire",
+    "email": "pkfire@uci.edu",
+    "gender": "Other",
+    "pronouns": ["pk"],
+    "ethnicity": "fire",
+    "is_18_older": "true",
+    "university": "UC Irvine",
+    "education_level": "Fifth+ Year Undergraduate",
+    "major": "Computer Science",
+    "is_first_hackathon": "false",
+    "stress_relief_question": "I am pkfire",
+    "company_specialize_question": "I am pkfire",
+}
+
+SAMPLE_RESUME = ("my-resume.pdf", b"resume", "application/pdf")
+SAMPLE_FILES = {"resume": SAMPLE_RESUME}
+BAD_RESUME = ("bad-resume.doc", b"resume", "application/msword")
+LARGE_RESUME = ("large-resume.pdf", b"resume" * 100_000, "application/pdf")
+
+EXPECTED_RESUME_UPLOAD = ("pk-fire-69f2afc2.pdf", b"resume", "application/pdf")
+SAMPLE_RESUME_URL = "https://drive.google.com/file/d/..."
+SAMPLE_SUBMISSION_TIME = datetime(2023, 1, 12, 8, 1, 21)
+SAMPLE_VERDICT_TIME = None
+
+EXPECTED_APPLICATION_DATA = ProcessedApplicationData(
+    **SAMPLE_APPLICATION,
+    resume_url=SAMPLE_RESUME_URL,
+    submission_time=SAMPLE_SUBMISSION_TIME,
+    verdict_time=SAMPLE_VERDICT_TIME,
+)
+
+EXPECTED_APPLICATION_DATA_WITHOUT_RESUME = ProcessedApplicationData(
+    **SAMPLE_APPLICATION,
+    resume_url=None,
+    submission_time=SAMPLE_SUBMISSION_TIME,
+    verdict_time=SAMPLE_VERDICT_TIME,
+)
+
+EXPECTED_USER = Applicant(
+    _id="edu.uci.pkfire",
+    status="PENDING_REVIEW",
+    application_data=EXPECTED_APPLICATION_DATA,
+)
+
+EXPECTED_USER_WITHOUT_RESUME = Applicant(
+    _id="edu.uci.pkfire",
+    application_data=EXPECTED_APPLICATION_DATA_WITHOUT_RESUME,
+    status="PENDING_REVIEW",
+)
+
+resume_handler.RESUMES_FOLDER_ID = "RESUMES_FOLDER_ID"
+
+app = FastAPI()
+app.include_router(user.router)
+
+client = UserTestClient(USER_PKFIRE, app)
+
+
+@patch("utils.email_handler.send_application_confirmation_email", autospec=True)
+@patch("services.mongodb_handler.update_one", autospec=True)
+@patch("routers.user.datetime", autospec=True)
+@patch("services.gdrive_handler.upload_file", autospec=True)
+@patch("services.mongodb_handler.retrieve_one", autospec=True)
+def test_apply_successfully(
+    mock_mongodb_handler_retrieve_one: AsyncMock,
+    mock_gdrive_handler_upload_file: AsyncMock,
+    mock_datetime: Mock,
+    mock_mongodb_handler_update_one: AsyncMock,
+    mock_send_application_confirmation_email: AsyncMock,
+) -> None:
+    """Test that a valid application is submitted properly."""
+    mock_mongodb_handler_retrieve_one.return_value = None
+    mock_gdrive_handler_upload_file.return_value = SAMPLE_RESUME_URL
+    mock_datetime.now.return_value = SAMPLE_SUBMISSION_TIME
+    res = client.post("/apply", data=SAMPLE_APPLICATION, files=SAMPLE_FILES)
+
+    mock_gdrive_handler_upload_file.assert_awaited_once_with(
+        resume_handler.RESUMES_FOLDER_ID, *EXPECTED_RESUME_UPLOAD
+    )
+    mock_mongodb_handler_update_one.assert_awaited_once_with(
+        Collection.USERS, {"_id": EXPECTED_USER.uid}, EXPECTED_USER.dict(), upsert=True
+    )
+    mock_send_application_confirmation_email.assert_awaited_once_with(
+        EXPECTED_APPLICATION_DATA
+    )
+    assert res.status_code == 201
+
+
+@patch("services.mongodb_handler.retrieve_one", autospec=True)
+def test_apply_with_invalid_data_causes_422(
+    mock_mongodb_handler_retrieve_one: AsyncMock,
+) -> None:
+    """Test that applying with invalid data is unprocessable."""
+    bad_application = SAMPLE_APPLICATION.copy()
+    bad_application["email"] = "not-an-email"
+    res = client.post("/apply", data=bad_application, files=SAMPLE_FILES)
+
+    mock_mongodb_handler_retrieve_one.assert_not_called()
+    assert res.status_code == 422
+
+
+@patch("services.gdrive_handler.upload_file", autospec=True)
+@patch("services.mongodb_handler.retrieve_one", autospec=True)
+def test_apply_when_user_exists_causes_400(
+    mock_mongodb_handler_retrieve_one: AsyncMock,
+    mock_gdrive_handler_upload_file: AsyncMock,
+) -> None:
+    """Test that applying when a user already exists causes status 400."""
+    mock_mongodb_handler_retrieve_one.return_value = {
+        "_id": "edu.uci.pkfire",
+        "status": "pending review",
+    }
+    res = client.post("/apply", data=SAMPLE_APPLICATION, files=SAMPLE_FILES)
+
+    mock_gdrive_handler_upload_file.assert_not_called()
+    assert res.status_code == 400
+
+
+@patch("services.mongodb_handler.retrieve_one", autospec=True)
+def test_apply_with_invalid_resume_type_causes_415(
+    mock_mongodb_handler_retrieve_one: AsyncMock,
+) -> None:
+    """Test that applying with an invalid resume type is unprocessable."""
+    mock_mongodb_handler_retrieve_one.return_value = None
+    res = client.post("/apply", data=SAMPLE_APPLICATION, files={"resume": BAD_RESUME})
+
+    assert res.status_code == 415
+
+
+@patch("services.gdrive_handler.upload_file", autospec=True)
+@patch("services.mongodb_handler.retrieve_one", autospec=True)
+def test_apply_with_large_resume_causes_413(
+    mock_mongodb_handler_retrieve_one: AsyncMock,
+    mock_gdrive_handler_upload_file: AsyncMock,
+) -> None:
+    """Test that a request with a resume over the size limit causes status 413."""
+    mock_mongodb_handler_retrieve_one.return_value = None
+    res = client.post("/apply", data=SAMPLE_APPLICATION, files={"resume": LARGE_RESUME})
+
+    mock_gdrive_handler_upload_file.assert_not_called()
+    assert res.status_code == 413
+
+
+@patch("services.gdrive_handler.upload_file", autospec=True)
+@patch("services.mongodb_handler.retrieve_one", autospec=True)
+def test_apply_with_resume_upload_issue_causes_500(
+    mock_mongodb_handler_retrieve_one: AsyncMock,
+    mock_gdrive_handler_upload_file: AsyncMock,
+) -> None:
+    """Test that an issue with the resume upload causes status 500."""
+    mock_mongodb_handler_retrieve_one.return_value = None
+    mock_gdrive_handler_upload_file.side_effect = HTTPError("Google Drive error")
+    res = client.post("/apply", data=SAMPLE_APPLICATION, files=SAMPLE_FILES)
+
+    assert res.status_code == 500
+
+
+@patch("utils.email_handler.send_application_confirmation_email", autospec=True)
+@patch("services.mongodb_handler.update_one", autospec=True)
+@patch("services.gdrive_handler.upload_file", autospec=True)
+@patch("services.mongodb_handler.retrieve_one", autospec=True)
+def test_apply_with_user_insert_issue_causes_500(
+    mock_mongodb_handler_retrieve_one: AsyncMock,
+    mock_gdrive_handler_upload_file: AsyncMock,
+    mock_mongodb_handler_update_one: AsyncMock,
+    mock_send_application_confirmation_email: AsyncMock,
+) -> None:
+    """Test that an issue with inserting a user into MongoDB causes status 500."""
+    mock_mongodb_handler_retrieve_one.return_value = None
+    mock_gdrive_handler_upload_file.return_value = SAMPLE_RESUME_URL
+    mock_mongodb_handler_update_one.side_effect = RuntimeError
+    res = client.post("/apply", data=SAMPLE_APPLICATION, files=SAMPLE_FILES)
+
+    mock_mongodb_handler_update_one.assert_awaited_once()
+    mock_send_application_confirmation_email.assert_not_called()
+    assert res.status_code == 500
+
+
+@patch("utils.email_handler.send_application_confirmation_email", autospec=True)
+@patch("services.mongodb_handler.update_one", autospec=True)
+@patch("services.gdrive_handler.upload_file", autospec=True)
+@patch("services.mongodb_handler.retrieve_one", autospec=True)
+def test_apply_with_confirmation_email_issue_causes_500(
+    mock_mongodb_handler_retrieve_one: AsyncMock,
+    mock_gdrive_handler_upload_file: AsyncMock,
+    mock_mongodb_handler_update_one: AsyncMock,
+    mock_send_application_confirmation_email: AsyncMock,
+) -> None:
+    """Test that an issue with sending the confirmation email causes status 500."""
+    mock_mongodb_handler_retrieve_one.return_value = None
+    mock_gdrive_handler_upload_file.return_value = SAMPLE_RESUME_URL
+    mock_send_application_confirmation_email.side_effect = RuntimeError
+    res = client.post("/apply", data=SAMPLE_APPLICATION, files=SAMPLE_FILES)
+
+    mock_mongodb_handler_update_one.assert_awaited_once()
+    mock_send_application_confirmation_email.assert_awaited_once()
+    assert res.status_code == 500
+
+
+@patch("utils.email_handler.send_application_confirmation_email", autospec=True)
+@patch("services.mongodb_handler.update_one", autospec=True)
+@patch("routers.user.datetime", autospec=True)
+@patch("services.gdrive_handler.upload_file", autospec=True)
+@patch("services.mongodb_handler.retrieve_one", autospec=True)
+def test_apply_successfully_without_resume(
+    mock_mongodb_handler_retrieve_one: AsyncMock,
+    mock_gdrive_handler_upload_file: AsyncMock,
+    mock_datetime: Mock,
+    mock_mongodb_handler_update_one: AsyncMock,
+    mock_send_application_confirmation_email: AsyncMock,
+) -> None:
+    """Test that a valid application is submitted properly without a resume."""
+    mock_mongodb_handler_retrieve_one.return_value = None
+    mock_datetime.now.return_value = SAMPLE_SUBMISSION_TIME
+    res = client.post("/apply", data=SAMPLE_APPLICATION, files=None)
+
+    mock_gdrive_handler_upload_file.assert_not_called()
+    mock_mongodb_handler_update_one.assert_awaited_once_with(
+        Collection.USERS,
+        {"_id": EXPECTED_USER.uid},
+        EXPECTED_USER_WITHOUT_RESUME.dict(),
+        upsert=True,
+    )
+    mock_send_application_confirmation_email.assert_awaited_once_with(
+        EXPECTED_APPLICATION_DATA_WITHOUT_RESUME
+    )
+    assert res.status_code == 201

--- a/apps/api/tests/test_user_apply.py
+++ b/apps/api/tests/test_user_apply.py
@@ -22,16 +22,15 @@ USER_PKFIRE = NativeUser(
 SAMPLE_APPLICATION = {
     "first_name": "pk",
     "last_name": "fire",
-    "email": "pkfire@uci.edu",
     "pronouns": "pk",
     "ethnicity": "fire",
     "is_18_older": "true",
-    "university": "UC Irvine",
+    "school": "UC Irvine",
     "education_level": "Fifth+ Year Undergraduate",
     "major": "Computer Science",
     "is_first_hackathon": "false",
-    "collaboration_question": "I am pkfire",
-    "any_job_question": "I am pkfire",
+    "frq_collaboration": "I am pkfire",
+    "frq_dream_job": "I am pkfire",
 }
 
 SAMPLE_RESUME = ("my-resume.pdf", b"resume", "application/pdf")
@@ -117,7 +116,7 @@ def test_apply_with_invalid_data_causes_422(
 ) -> None:
     """Test that applying with invalid data is unprocessable."""
     bad_application = SAMPLE_APPLICATION.copy()
-    bad_application["email"] = "not-an-email"
+    bad_application["is_18_older"] = "maybe"
     res = client.post("/apply", data=bad_application, files=SAMPLE_FILES)
 
     mock_mongodb_handler_retrieve_one.assert_not_called()

--- a/apps/site/src/app/apply/sections/Form/AgeInformation.tsx
+++ b/apps/site/src/app/apply/sections/Form/AgeInformation.tsx
@@ -30,7 +30,7 @@ export default function AgeInformation() {
 			</div>
 
 			<SimpleRadio
-				name="minor_check"
+				name="is_18_older"
 				values={yesNoOptions}
 				title="Will you be 18 years or older by January 26th, 2024?"
 				titleClass="text-xl font-bold m-0 text-center"

--- a/apps/site/src/app/apply/sections/Form/ProfileInformation.tsx
+++ b/apps/site/src/app/apply/sections/Form/ProfileInformation.tsx
@@ -33,7 +33,7 @@ export default function ProfileInformation() {
 			</div>
 
 			<Textfield
-				name="collaboration_answer"
+				name="frq_collaboration"
 				labelClass={`${styles.label} mt-7`}
 				labelText="Why is collaboration important to being a programmer or technologist, and what does it mean to you? (150 words)"
 				inputClass={`bg-[#E1E1E1] p-3 h-48 resize-none rounded-xl`}
@@ -42,7 +42,7 @@ export default function ProfileInformation() {
 			/>
 
 			<Textfield
-				name="job_answer"
+				name="frq_dream_job"
 				labelClass={`${styles.label} mt-7`}
 				labelText="If you could have any job in the world, what would it be? (ex. YouTuber, Body Builder, etc.) (100 words)"
 				inputClass={`bg-[#E1E1E1] p-3 h-48 resize-none rounded-xl`}

--- a/apps/site/src/app/apply/sections/Form/ResumeInformation.tsx
+++ b/apps/site/src/app/apply/sections/Form/ResumeInformation.tsx
@@ -75,7 +75,7 @@ export default function ResumeInformation() {
 			<input
 				ref={inputRef}
 				className="opacity-0 absolute"
-				name="resume_upload"
+				name="resume"
 				id="resume_upload"
 				type="file"
 				accept="application/pdf"

--- a/apps/site/src/app/apply/sections/Form/SchoolInformation.tsx
+++ b/apps/site/src/app/apply/sections/Form/SchoolInformation.tsx
@@ -79,7 +79,7 @@ export default function SchoolInformation() {
 				<DropdownSelect
 					labelStyle={styles.label}
 					inputStyle={styles.input}
-					name="school_name"
+					name="school"
 					labelText="School Name"
 					values={universityOptions}
 					containerClass="flex flex-col w-6/12 max-[1000px]:w-full"
@@ -97,7 +97,7 @@ export default function SchoolInformation() {
 				/>
 
 				<SimpleRadio
-					name="hack_check"
+					name="is_first_hackathon"
 					values={yesNoOptions}
 					title="Is this your first Hackathon?"
 					titleClass="text-lg mb-0 p-0"


### PR DESCRIPTION
To accept hacker applications, the API needs to process the application form data. The `/user/apply` endpoint was imported mostly as is with minor improvements (see commit history for changes after import) to typing and one change about acquiring the applicant's email.

Lingering issues:
- Form fields with "Other" options are currently not received
  - As noted in #90, this can be handled with client-side submission, but ideally the API also takes care of it
- The resume upload is currently required (see #111)
  - When no file upload is included, the browser will still send an empty octet-stream in the native post request
  - Same note as above about API handling vs client-side submission

Closes #93.

## Changes
- Import last year's user apply endpoint/tests as is
  - Import `/apply` route in user router, user record models, and tests from last year's [HackAtUCI/HackUCI-Site](https://github.com/HackAtUCI/HackUCI-Site) repository
- Fix user apply types, tests, and models
  - [`Optional` values no longer default to `None` in Pydantic V2](https://docs.pydantic.dev/2.0/migration/#required-optional-and-nullable-fields)
  - Replace model `dict` with `model_dump`
  - Update sample fields in unit test based on changes to application
  - Fix other type errors
    - Specify type for `Applicant.Role`
    - Use `Status` Enum value in expected `Applicant` object
    - Ignore arg-type error when constructing sample application data
- Add `HttpUrl` type to resume upload
- Fix application form field name correspondence
  - Update application form field names to match between frontend and API
- Fix URL serialization from Pydantic to Mongo BSON
  - Include `field_serializer` in `ProcessedApplicationData` to convert `HttpUrl`s to `str`
  - Add unit test to confirm application data can be BSON-serialized
- Use user email from identity for confirmation
  - Last year's application form had a redundant email field which was removed this year
  - Use the email from the user identity for sending the application confirmation email
- Use `Annotated` syntax for /apply endpoint params

## Testing
1. Temporarily disable the resume upload and email handler by immediately calling `return`
2. Load the Docker environment for the API
3. Open the site with the application form on `/apply`
4. Complete the application with standard (non-other) values and a resume file
5. Observe the application is properly received by the API