### PR TITLE
Fix Flashing Form Validation

### DIFF
--- a/apps/site/src/lib/components/ValidatingForm/ValidatingForm.tsx
+++ b/apps/site/src/lib/components/ValidatingForm/ValidatingForm.tsx
@@ -17,8 +17,8 @@ function ValidatingForm(props: PropsWithChildren<FormProps>) {
 		if (!form.checkValidity()) {
 			// prevent submission to display validation feedback
 			event.preventDefault();
+			setValidated(true);
 		}
-		setValidated(true);
 	};
 
 	return (


### PR DESCRIPTION
Only show validation messages if form is failing since the user is going to be redirected if successful anyways.