### PR TITLE
Implement client-side application form submission

### DIFF
--- a/apps/site/src/app/apply/sections/Components/DropdownSelect.tsx
+++ b/apps/site/src/app/apply/sections/Components/DropdownSelect.tsx
@@ -26,7 +26,7 @@ const OtherPopup = ({ value, name }: OtherProps) => {
 				</label>
 				<input
 					type="text"
-					name={`${name}-other-input`}
+					name={`other_${name}`}
 					id={`${name}-other-input`}
 					className="border-b-2 p-1 h-6 border-black w-6/12"
 					required

--- a/apps/site/src/app/apply/sections/Components/RadioSelect.tsx
+++ b/apps/site/src/app/apply/sections/Components/RadioSelect.tsx
@@ -10,17 +10,17 @@ interface RadioInputs {
 	containerClass: string;
 }
 
-interface IsChecked {
+interface OtherInputProps {
 	isChecked: boolean;
-	id: string;
+	name: string;
 }
 
-const OtherInput = forwardRef<HTMLInputElement, IsChecked>(
-	({ isChecked, id }, ref) => (
+const OtherInput = forwardRef<HTMLInputElement, OtherInputProps>(
+	({ isChecked, name }, ref) => (
 		<input
 			ref={ref}
 			type="text"
-			name={`${id}-other`}
+			name={name}
 			className={
 				isChecked
 					? "border-b-2 p-1 h-6 border-black w-6/12"
@@ -76,7 +76,7 @@ export default function RadioSelect({
 								</label>
 								<OtherInput
 									isChecked={isOtherChecked}
-									id={IdentifierId}
+									name={`other_${name}`}
 									ref={otherRef}
 								/>
 							</div>

--- a/apps/site/src/app/apply/sections/Form/Form.tsx
+++ b/apps/site/src/app/apply/sections/Form/Form.tsx
@@ -18,6 +18,7 @@ const FIELDS_WITH_OTHER = ["pronouns", "ethnicity", "school", "major"];
 
 export default function Form() {
 	const [submitting, setSubmitting] = useState(false);
+	const [sessionExpired, setSessionExpired] = useState(false);
 
 	const handleSubmit = async (
 		event: FormEvent<HTMLFormElement>,
@@ -25,6 +26,7 @@ export default function Form() {
 		// Disable native post submission
 		event.preventDefault();
 		setSubmitting(true);
+		setSessionExpired(false);
 
 		const formData = new FormData(event.currentTarget);
 
@@ -47,12 +49,30 @@ export default function Form() {
 				// TODO: show submitted message
 			}
 		} catch (err) {
-			// TODO: unauthorized error
 			console.error(err);
+			if (axios.isAxiosError(err)) {
+				if (err.response?.status === 401) {
+					setSessionExpired(true);
+				}
+			}
 		}
 
 		setSubmitting(false);
 	};
+
+	const sessionExpiredMessage = (
+		<p className="text-red-500">
+			Your session has expired. Please{" "}
+			<a
+				href="/login"
+				target="_blank"
+				className="text-blue-600 underline"
+			>
+				log in from a new tab
+			</a>{" "}
+			to restore your session and then try submitting again.
+		</p>
+	);
 
 	return (
 		<form
@@ -68,6 +88,7 @@ export default function Form() {
 			<ResumeInformation />
 			<AgeInformation />
 			<Button text="Submit Application" disabled={submitting} />
+			{sessionExpired && sessionExpiredMessage}
 		</form>
 	);
 }

--- a/apps/site/src/app/apply/sections/Form/Form.tsx
+++ b/apps/site/src/app/apply/sections/Form/Form.tsx
@@ -1,3 +1,8 @@
+"use client";
+
+import { FormEvent } from "react";
+import axios from "axios";
+
 import Button from "@/lib/components/Button/Button";
 
 import BasicInformation from "./BasicInformation";
@@ -8,13 +13,49 @@ import ResumeInformation from "./ResumeInformation";
 
 import styles from "./Form.module.scss";
 
+const APPLY_PATH = "/api/user/apply";
+const FIELDS_WITH_OTHER = ["pronouns", "ethnicity", "school", "major"];
+
 export default function Form() {
+	const handleSubmit = async (
+		event: FormEvent<HTMLFormElement>,
+	): Promise<void> => {
+		// Disable native post submission
+		event.preventDefault();
+
+		const formData = new FormData(event.currentTarget);
+
+		// Use other values when selected
+		for (const field of FIELDS_WITH_OTHER) {
+			const otherField = `other_${field}`;
+			if (formData.get(field) === "other") {
+				formData.set(field, formData.get(otherField)!);
+				formData.delete(otherField);
+			}
+		}
+
+		const formEntries = Object.fromEntries(formData.entries());
+		console.debug(formEntries);
+
+		try {
+			const res = await axios.post(APPLY_PATH, formData);
+			if (res.status === 201) {
+				console.log("Application submitted");
+				// TODO: show submitted message
+			}
+		} catch (err) {
+			// TODO: unauthorized error
+			console.error(err);
+		}
+	};
+
 	return (
 		<form
 			method="post"
 			className={`${styles.form} text-[#000000] w-8/12 flex flex-col items-center py-12 gap-10 z-1 max-[800px]:w-9/12 max-[400px]:w-11/12`}
 			action="/api/user/apply"
 			encType="multipart/form-data"
+			onSubmit={handleSubmit}
 		>
 			<BasicInformation />
 			<SchoolInformation />

--- a/apps/site/src/app/apply/sections/Form/Form.tsx
+++ b/apps/site/src/app/apply/sections/Form/Form.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { FormEvent } from "react";
+import { FormEvent, useState } from "react";
 import axios from "axios";
 
 import Button from "@/lib/components/Button/Button";
@@ -17,11 +17,14 @@ const APPLY_PATH = "/api/user/apply";
 const FIELDS_WITH_OTHER = ["pronouns", "ethnicity", "school", "major"];
 
 export default function Form() {
+	const [submitting, setSubmitting] = useState(false);
+
 	const handleSubmit = async (
 		event: FormEvent<HTMLFormElement>,
 	): Promise<void> => {
 		// Disable native post submission
 		event.preventDefault();
+		setSubmitting(true);
 
 		const formData = new FormData(event.currentTarget);
 
@@ -47,6 +50,8 @@ export default function Form() {
 			// TODO: unauthorized error
 			console.error(err);
 		}
+
+		setSubmitting(false);
 	};
 
 	return (
@@ -62,7 +67,7 @@ export default function Form() {
 			<ProfileInformation />
 			<ResumeInformation />
 			<AgeInformation />
-			<Button text="Submit Application" />
+			<Button text="Submit Application" disabled={submitting} />
 		</form>
 	);
 }

--- a/apps/site/src/lib/components/Button/Button.tsx
+++ b/apps/site/src/lib/components/Button/Button.tsx
@@ -8,6 +8,7 @@ interface ButtonProps {
 	href?: string;
 	isLightVersion?: boolean;
 	usePrefetch?: boolean;
+	disabled?: boolean;
 }
 
 const Button: React.FC<ButtonProps> = ({
@@ -15,6 +16,7 @@ const Button: React.FC<ButtonProps> = ({
 	href,
 	className,
 	isLightVersion,
+	disabled,
 }) => {
 	if (href) {
 		return (
@@ -32,7 +34,11 @@ const Button: React.FC<ButtonProps> = ({
 		);
 	}
 	return (
-		<button type="submit" className={styles.button + " font-body"}>
+		<button
+			type="submit"
+			className={styles.button + " font-body"}
+			disabled={disabled}
+		>
 			{text}
 		</button>
 	);


### PR DESCRIPTION
To handle error cases and show the submission completed message, the application form can be submitted asynchronously from the client with axios. This handles the unauthorized case and the success case can be handled separately as part of the entire Apply page flow in #108.

I decided not to omit the empty resume file (empty octet stream) since the API should be reinforced to handle that (in case JavaScript is disabled) as part of #93.

The form submission handler could have been implemented as a [Next.js server action](https://nextjs.org/docs/app/building-your-application/data-fetching/server-actions-and-mutations) which would alleviate some of our concerns about JavaScript being disabled, but we are currently using [Next.js v13 where server actions are considered experimental](https://nextjs.org/docs/app/api-reference/next-config-js/serverActions#enabling-server-actions-v13). To avoid potentially breaking changes, we can revisit upgrading to v14 after our application release.

Closes #90.

## Changes
- Implement client-side application form submission
  - Use axios to handle application submission on the client
    - Substitute write-in values marked as "other"
- Disable Apply form submit button while submitting
  - When submitting, disable the submit button so the user doesn't accidentally submit twice
- Handle session expiration in application form
  - When apply form submission encounters status 401, show session expired message instructing user to log in again from a new tab

## Testing
1. Open the application form at `/apply`
2. Select "Other" options for the fields that have such and provide a write-in value
3. Submit the application and observe the other values are substituted in the form data (console.debug)
4. Observe the session expired message appears below the submit button