### PR TITLE
feat: handle application when JS disabled

### DIFF
--- a/apps/api/src/routers/user.py
+++ b/apps/api/src/routers/user.py
@@ -72,6 +72,15 @@ async def apply(
         log.error("User %s has already applied.", user)
         raise HTTPException(status.HTTP_400_BAD_REQUEST)
 
+    raw_app_data_dump = raw_application_data.model_dump()
+
+    for field in ["pronouns", "ethnicity", "school", "major"]:
+        if raw_app_data_dump[field] == "other":
+            raise HTTPException(
+                status.HTTP_422_UNPROCESSABLE_ENTITY,
+                "Please enable JavaScript on your browser.",
+            )
+
     if resume is not None:
         try:
             resume_url = await resume_handler.upload_resume(
@@ -95,7 +104,7 @@ async def apply(
 
     now = datetime.now(timezone.utc)
     processed_application_data = ProcessedApplicationData(
-        **raw_application_data.model_dump(),
+        **raw_app_data_dump,
         resume_url=resume_url,
         submission_time=now,
     )

--- a/apps/api/tests/test_user_apply.py
+++ b/apps/api/tests/test_user_apply.py
@@ -36,20 +36,6 @@ SAMPLE_APPLICATION = {
     "frq_dream_job": "I am pkfire",
 }
 
-SAMPLE_APPLICATION_NO_JS = {
-    "first_name": "pk",
-    "last_name": "fire",
-    "pronouns": "other",
-    "ethnicity": "fire",
-    "is_18_older": "true",
-    "school": "UC Irvine",
-    "education_level": "Fifth+ Year Undergraduate",
-    "major": "Computer Science",
-    "is_first_hackathon": "false",
-    "portfolio": "https://github.com",
-    "frq_collaboration": "I am pkfire",
-    "frq_dream_job": "I am pkfire",
-}
 
 SAMPLE_RESUME = ("my-resume.pdf", b"resume", "application/pdf")
 SAMPLE_FILES = {"resume": SAMPLE_RESUME}
@@ -277,17 +263,11 @@ def test_application_data_is_bson_encodable() -> None:
     assert len(encoded) == 415
 
 
-@patch("utils.email_handler.send_application_confirmation_email", autospec=True)
-@patch("services.mongodb_handler.update_one", autospec=True)
-@patch("routers.user.datetime", autospec=True)
-@patch("services.gdrive_handler.upload_file", autospec=True)
 @patch("services.mongodb_handler.retrieve_one", autospec=True)
-def test_application_data_with_other_throws_400(
+def test_application_data_with_other_throws_422(
     mock_mongodb_handler_retrieve_one: AsyncMock,
-    mock_gdrive_handler_upload_file: AsyncMock,
-    mock_datetime: Mock,
-    mock_mongodb_handler_update_one: AsyncMock,
-    mock_send_application_confirmation_email: AsyncMock,
 ) -> None:
-    res = client.post("/apply", data=SAMPLE_APPLICATION_NO_JS, files=SAMPLE_FILES)
+    contains_other = SAMPLE_APPLICATION.copy()
+    contains_other["pronouns"] = "other"
+    res = client.post("/apply", data=contains_other, files=SAMPLE_FILES)
     assert res.status_code == 422

--- a/apps/api/tests/test_user_apply.py
+++ b/apps/api/tests/test_user_apply.py
@@ -36,6 +36,21 @@ SAMPLE_APPLICATION = {
     "frq_dream_job": "I am pkfire",
 }
 
+SAMPLE_APPLICATION_NO_JS = {
+    "first_name": "pk",
+    "last_name": "fire",
+    "pronouns": "other",
+    "ethnicity": "fire",
+    "is_18_older": "true",
+    "school": "UC Irvine",
+    "education_level": "Fifth+ Year Undergraduate",
+    "major": "Computer Science",
+    "is_first_hackathon": "false",
+    "portfolio": "https://github.com",
+    "frq_collaboration": "I am pkfire",
+    "frq_dream_job": "I am pkfire",
+}
+
 SAMPLE_RESUME = ("my-resume.pdf", b"resume", "application/pdf")
 SAMPLE_FILES = {"resume": SAMPLE_RESUME}
 BAD_RESUME = ("bad-resume.doc", b"resume", "application/msword")
@@ -260,3 +275,19 @@ def test_application_data_is_bson_encodable() -> None:
     data.linkedin = HttpUrl("https://linkedin.com")
     encoded = bson.encode(EXPECTED_APPLICATION_DATA.model_dump())
     assert len(encoded) == 415
+
+
+@patch("utils.email_handler.send_application_confirmation_email", autospec=True)
+@patch("services.mongodb_handler.update_one", autospec=True)
+@patch("routers.user.datetime", autospec=True)
+@patch("services.gdrive_handler.upload_file", autospec=True)
+@patch("services.mongodb_handler.retrieve_one", autospec=True)
+def test_application_data_with_other_throws_400(
+    mock_mongodb_handler_retrieve_one: AsyncMock,
+    mock_gdrive_handler_upload_file: AsyncMock,
+    mock_datetime: Mock,
+    mock_mongodb_handler_update_one: AsyncMock,
+    mock_send_application_confirmation_email: AsyncMock,
+) -> None:
+    res = client.post("/apply", data=SAMPLE_APPLICATION_NO_JS, files=SAMPLE_FILES)
+    assert res.status_code == 422


### PR DESCRIPTION
In scenarios like these, the value "other" will be sent instead of the value the user provided when selecting the "other" option.

- Raise an `HTTPException` with status `422 Unprocessable Entity` when receiving such an error
- Write a unit test to test an application with a field containing "other" as its value