### PR TITLE
Fix guest UID generation with double dot

### DIFF
--- a/apps/api/src/auth/user_identity.py
+++ b/apps/api/src/auth/user_identity.py
@@ -67,7 +67,7 @@ def scoped_uid(email: EmailStr) -> str:
         raise ValueError("UCI user should use NativeUser")
     local, domain = email.split("@")
     reversed_domains = ".".join(reversed(domain.split(".")))
-    cleaned_local = local.replace(".", "-")
+    cleaned_local = local.replace(".", "..")
     return f"{reversed_domains}.{cleaned_local}"
 
 

--- a/apps/api/tests/test_user_identity.py
+++ b/apps/api/tests/test_user_identity.py
@@ -44,7 +44,7 @@ def test_scoped_uid_with_dots() -> None:
     """Test scoped uid properly processes local and domain parts."""
     assert user_identity.scoped_uid("kate@cc.edu") == "edu.cc.kate"
     assert user_identity.scoped_uid("kate@student.cc.edu") == "edu.cc.student.kate"
-    assert user_identity.scoped_uid("student.kate@cc.edu") == "edu.cc.student-kate"
+    assert user_identity.scoped_uid("student.kate@cc.edu") == "edu.cc.student..kate"
 
 
 def test_empty_identity_with_empty_token() -> None:


### PR DESCRIPTION
- The previous fix of replacing dots with dashes was not exhaustive
- Replace dots with double dots to ensure collision avoidance

Resolves #119.