### PR TITLE
Fix validation message display in `ValidatingForm`

### DIFF
--- a/apps/site/src/app/guest-login/components/VerificationForm.tsx
+++ b/apps/site/src/app/guest-login/components/VerificationForm.tsx
@@ -44,7 +44,7 @@ function VerificationForm() {
 						A login passphrase was sent to your email. Please enter
 						the passphrase.
 					</small>
-					<p className={clsx(styles.invalidated, "text-red-500")}>
+					<p className={clsx(styles.invalidFeedback, "text-red-500")}>
 						Sorry, that passphrase is invalid.
 					</p>
 				</div>

--- a/apps/site/src/app/login/components/LoginForm.tsx
+++ b/apps/site/src/app/login/components/LoginForm.tsx
@@ -27,7 +27,7 @@ function LoginForm() {
 						UCI students will log in with UCI SSO. Please make sure
 						to use your school email address if you have one.
 					</small>
-					<p className={clsx(styles.invalidated, "text-red-500")}>
+					<p className={clsx(styles.invalidFeedback, "text-red-500")}>
 						Sorry, that email address is invalid.
 					</p>
 				</div>

--- a/apps/site/src/lib/components/ValidatingForm/ValidatingForm.module.scss
+++ b/apps/site/src/lib/components/ValidatingForm/ValidatingForm.module.scss
@@ -1,9 +1,9 @@
-.validated {
-	&:invalid .invalidated {
-		display: block;
-	}
+.invalidFeedback {
+	display: none;
 }
 
-.notYetValidated .invalidated {
-	display: none;
+.validated {
+	:invalid ~ .invalidFeedback {
+		display: block;
+	}
 }


### PR DESCRIPTION
Follow up from #114, closes #123.

## Changes
- Use more specific class selectors to show invalid feedback only when form was validated and input is `:invalid`, similar to Bootstrap v5

## Testing
1. Manually insert `event.preventDefault()` at the end of `handleSubmit` in `ValidatingForm`
2. Enter an invalid email in the Login page form
3. Observe the invalid feedback shows
4. Correct the input to a valid email
5. Observe the invalid feedback disappears without resubmitting
6. Observe the invalid feedback stays hidden "while submitting"
7. Repeat steps 2–6 with the guest passphrase verification and a malformed passphrase