### PR TITLE
Enforce FRQ character limit on application form

### DIFF
--- a/apps/api/src/models/ApplicationData.py
+++ b/apps/api/src/models/ApplicationData.py
@@ -31,8 +31,8 @@ class RawApplicationData(BaseModel):
     is_first_hackathon: bool
     linkedin: Union[HttpUrl, None] = None
     portfolio: Union[HttpUrl, None] = None
-    frq_collaboration: Union[str, None] = Field(None, max_length=1024)
-    frq_dream_job: str = Field(max_length=1024)
+    frq_collaboration: Union[str, None] = Field(None, max_length=2048)
+    frq_dream_job: str = Field(max_length=2048)
 
 
 class ProcessedApplicationData(RawApplicationData):

--- a/apps/site/src/app/apply/sections/Components/Textfield.tsx
+++ b/apps/site/src/app/apply/sections/Components/Textfield.tsx
@@ -7,6 +7,7 @@ interface TextfieldProps {
 	inputClass: string;
 	containerClass: string;
 	isRequired: boolean;
+	maxLength?: number;
 }
 
 export default function Textfield({
@@ -16,6 +17,7 @@ export default function Textfield({
 	inputClass,
 	containerClass,
 	isRequired,
+	maxLength,
 }: TextfieldProps) {
 	return (
 		<div className={containerClass}>
@@ -29,6 +31,7 @@ export default function Textfield({
 					id={name}
 					name={name}
 					required={isRequired}
+					maxLength={maxLength}
 				/>
 			</div>
 		</div>

--- a/apps/site/src/app/apply/sections/Form/ProfileInformation.tsx
+++ b/apps/site/src/app/apply/sections/Form/ProfileInformation.tsx
@@ -2,6 +2,8 @@ import TextInput from "@/app/apply/sections/Components/TextInput";
 import Textfield from "@/app/apply/sections/Components/Textfield";
 import styles from "./Form.module.scss";
 
+const FRQ_MAX_LENGTH = 2000;
+
 export default function ProfileInformation() {
 	return (
 		<div className="flex flex-col gap-5 w-11/12">
@@ -39,6 +41,7 @@ export default function ProfileInformation() {
 				inputClass={`bg-[#E1E1E1] p-3 h-48 resize-none rounded-xl`}
 				containerClass="flex flex-col w-full"
 				isRequired={true}
+				maxLength={FRQ_MAX_LENGTH}
 			/>
 
 			<Textfield
@@ -48,6 +51,7 @@ export default function ProfileInformation() {
 				inputClass={`bg-[#E1E1E1] p-3 h-48 resize-none rounded-xl`}
 				containerClass="flex flex-col w-full"
 				isRequired={true}
+				maxLength={FRQ_MAX_LENGTH}
 			/>
 		</div>
 	);


### PR DESCRIPTION
We received a user report of being unable to submit the application since the API rejected the application with status 405 because the FRQ answer was too long and no limit was present on the client-side form.

Resolves #151.

## Changes
- Double the character limit on FRQ answers (1024 -> 2048)
- Add `maxLength` to the `<textarea>` elements for FRQ answers
  - Form limit is slightly less since newlines are counted weirdly

## Testing
1. Open the application form
2. Complete all of the fields
3. Use a really long answer on either FRQ question
4. Observe the browser validation message appears when trying to submit
    > Use no more than 2000 characters (Safari)
    - Chrome does not seem to show any validation message
    - Both browsers will limit the amount of input characters but not exactly because of newline characters