### PR TITLE
Improve error logging when `getUserIdentity` fails

### DIFF
--- a/apps/site/src/lib/utils/getUserIdentity.ts
+++ b/apps/site/src/lib/utils/getUserIdentity.ts
@@ -14,9 +14,7 @@ export default async function getUserIdentity(): Promise<Identity> {
 		return identity.data;
 	} catch (err) {
 		if (axios.isAxiosError(err)) {
-			console.error(
-				`[getUserIdentity] ${err.message}: ${err.response?.data}`,
-			);
+			console.error(`[getUserIdentity] ${err.message}`);
 		} else {
 			// Don't think this case is possible/relevant but for completeness
 			console.error(err);

--- a/apps/site/src/lib/utils/getUserIdentity.ts
+++ b/apps/site/src/lib/utils/getUserIdentity.ts
@@ -1,3 +1,5 @@
+import axios from "axios";
+
 import api from "./api";
 
 export interface Identity {
@@ -6,10 +8,19 @@ export interface Identity {
 	status: string | null;
 }
 
-export default async function getUserIdentity() {
-	const identity = await api.get<Identity>("/user/me").catch((err) => {
-		console.log(err);
-		return { data: { uid: null, role: null, status: null } };
-	});
-	return identity.data;
+export default async function getUserIdentity(): Promise<Identity> {
+	try {
+		const identity = await api.get<Identity>("/user/me");
+		return identity.data;
+	} catch (err) {
+		if (axios.isAxiosError(err)) {
+			console.error(
+				`[getUserIdentity] ${err.message}: ${err.response?.data}`,
+			);
+		} else {
+			// Don't think this case is possible/relevant but for completeness
+			console.error(err);
+		}
+		return { uid: null, role: null, status: null };
+	}
 }


### PR DESCRIPTION
Reducing console spam when an issue with the API deployment causes `getUserIdentity` to fail.
Fixes #166.

## Changes
- Log just the Axios error message and API response data rather than the entire error object which floods the console
- Restructure `Promise.catch` into `try...catch`

## Testing
- Manually instructed the API to raise a `RuntimeError`
- Observed the Next.js console logs just the single desired line
  >[getUserIdentity] Request failed with status code 500: Internal Server Error