### PR TITLE
fix: copy additional shared objects for vercel-lib dependencies

### DIFF
--- a/apps/api/requirements.txt
+++ b/apps/api/requirements.txt
@@ -8,3 +8,4 @@ pydantic[email]==2.5.2
 aiosendgrid==0.1.0
 sendgrid==6.11.0
 aiogoogle==5.6.0
+lxml==5.0.0

--- a/apps/api/requirements.txt
+++ b/apps/api/requirements.txt
@@ -8,4 +8,3 @@ pydantic[email]==2.5.2
 aiosendgrid==0.1.0
 sendgrid==6.11.0
 aiogoogle==5.6.0
-lxml==5.0.0

--- a/apps/site/vercel-lib.sh
+++ b/apps/site/vercel-lib.sh
@@ -13,6 +13,9 @@ lib_files=(
    libxmlsec1.so.1.2.20
    libxslt.so.1
    libxslt.so.1.1.28
+   libexslt.so.0
+   libgcrypt.so.11
+   libgpg-error.so.0
 )
 
 mkdir lib

--- a/apps/site/vercel-lib.sh
+++ b/apps/site/vercel-lib.sh
@@ -1,7 +1,7 @@
 # Install python3-saml dependencies on Vercel's Serverless Function 
 # environment (Amazon Linux)
 
-yum install -y libxml2-devel xmlsec1-devel xmlsec1-openssl-devel libtool-ltdl-devel libxslt-devel libgcrypt-devel
+yum install -y libxml2-devel xmlsec1-devel xmlsec1-openssl-devel libtool-ltdl-devel libxslt-devel libgcrypt-devel libgpg-error-devel
 lib_files=(
    libltdl.so.7
    libltdl.so.7.3.0
@@ -15,6 +15,7 @@ lib_files=(
    libxslt.so.1.1.28
    libexslt.so.0
    libgcrypt.so.11
+   libgpg-error.so.0
 )
 
 mkdir lib

--- a/apps/site/vercel-lib.sh
+++ b/apps/site/vercel-lib.sh
@@ -1,7 +1,7 @@
 # Install python3-saml dependencies on Vercel's Serverless Function 
 # environment (Amazon Linux)
 
-yum install -y libxml2-devel xmlsec1-devel xmlsec1-openssl-devel libtool-ltdl-devel libxslt-devel libgcrypt-devel libgpg-error-devel
+yum install -y libxml2-devel xmlsec1-devel xmlsec1-openssl-devel libtool-ltdl-devel
 lib_files=(
    libltdl.so.7
    libltdl.so.7.3.0

--- a/apps/site/vercel-lib.sh
+++ b/apps/site/vercel-lib.sh
@@ -1,7 +1,7 @@
 # Install python3-saml dependencies on Vercel's Serverless Function 
 # environment (Amazon Linux)
 
-yum install -y libxml2-devel xmlsec1-devel xmlsec1-openssl-devel
+yum install -y libxml2-devel xmlsec1-devel xmlsec1-openssl-devel libtool-ltdl-devel
 lib_files=(
    libltdl.so.7
    libltdl.so.7.3.0
@@ -14,8 +14,11 @@ lib_files=(
    libxslt.so.1
    libxslt.so.1.1.28
    libexslt.so.0
+   libexslt.so.0.8.17
    libgcrypt.so.11
+   libgcrypt.so.11.8.2
    libgpg-error.so.0
+   libgpg-error.so.0.10.0
 )
 
 mkdir lib

--- a/apps/site/vercel-lib.sh
+++ b/apps/site/vercel-lib.sh
@@ -1,7 +1,7 @@
 # Install python3-saml dependencies on Vercel's Serverless Function 
 # environment (Amazon Linux)
 
-yum install -y libxml2-devel xmlsec1-devel xmlsec1-openssl-devel libtool-ltdl-devel libxslt-devel
+yum install -y libxml2-devel xmlsec1-devel xmlsec1-openssl-devel libtool-ltdl-devel libxslt-devel libgcrypt-devel
 lib_files=(
    libltdl.so.7
    libltdl.so.7.3.0
@@ -14,6 +14,7 @@ lib_files=(
    libxslt.so.1
    libxslt.so.1.1.28
    libexslt.so.0
+   libgcrypt.so.11
 )
 
 mkdir lib

--- a/apps/site/vercel-lib.sh
+++ b/apps/site/vercel-lib.sh
@@ -1,7 +1,7 @@
 # Install python3-saml dependencies on Vercel's Serverless Function 
 # environment (Amazon Linux)
 
-yum install -y libxml2-devel xmlsec1-devel xmlsec1-openssl-devel libtool-ltdl-devel
+yum install -y libxml2-devel xmlsec1-devel xmlsec1-openssl-devel libtool-ltdl-devel libxslt-devel
 lib_files=(
    libltdl.so.7
    libltdl.so.7.3.0

--- a/apps/site/vercel-lib.sh
+++ b/apps/site/vercel-lib.sh
@@ -1,7 +1,7 @@
 # Install python3-saml dependencies on Vercel's Serverless Function 
 # environment (Amazon Linux)
 
-yum install -y libxml2-devel xmlsec1-devel xmlsec1-openssl-devel libtool-ltdl-devel
+yum install -y libxml2-devel xmlsec1-devel xmlsec1-openssl-devel
 lib_files=(
    libltdl.so.7
    libltdl.so.7.3.0

--- a/apps/site/vercel-lib.sh
+++ b/apps/site/vercel-lib.sh
@@ -13,6 +13,7 @@ lib_files=(
    libxmlsec1.so.1.2.20
    libxslt.so.1
    libxslt.so.1.1.28
+   libexslt.so.0
 )
 
 mkdir lib

--- a/apps/site/vercel-lib.sh
+++ b/apps/site/vercel-lib.sh
@@ -13,9 +13,6 @@ lib_files=(
    libxmlsec1.so.1.2.20
    libxslt.so.1
    libxslt.so.1.1.28
-   libexslt.so.0
-   libgcrypt.so.11
-   libgpg-error.so.0
 )
 
 mkdir lib


### PR DESCRIPTION
Attempted resolution of #165 . Adding `libxslt-devel` as a package to install in `vercel-lib.sh` might resolve the issue.


## Update

Adding `libxslt-devel`, `libgcrypt-devel`, and `libgpg-error-devel` and then adding the missing files to the list of `.so` files to copy over in `vercel-lib.sh` resolved this issue. This was discovered mainly through trial and error, in which I installed the first package, then noticed that a different `.so` file was missing so I installed the package for that as well. This continued until no more missing `.so` file errors appeared in Vercel logs (i.e. after adding `libgpg-error-devel`).