### PR TITLE
fix: add `lxml<5.0.0` to `requirements.txt`

### DIFF
--- a/apps/api/requirements.txt
+++ b/apps/api/requirements.txt
@@ -8,3 +8,4 @@ pydantic[email]==2.5.2
 aiosendgrid==0.1.0
 sendgrid==6.11.0
 aiogoogle==5.6.0
+lxml<5.0.0

--- a/apps/api/requirements.txt
+++ b/apps/api/requirements.txt
@@ -8,4 +8,6 @@ pydantic[email]==2.5.2
 aiosendgrid==0.1.0
 sendgrid==6.11.0
 aiogoogle==5.6.0
+
+# To avoid breaking xmlsec for python3-saml
 lxml<5.0.0


### PR DESCRIPTION
Attempted resolution of #176 by forcing a version of `lxml` less than 5.0.0 to be downloaded.