### PR TITLE
fix: remove call to `_remove_guest_key`

### DIFF
--- a/apps/api/src/auth/guest_auth.py
+++ b/apps/api/src/auth/guest_auth.py
@@ -88,6 +88,9 @@ async def _get_existing_key(email: EmailStr) -> Optional[str]:
     # Reject expired key
     now = utc_now()
     if now > auth.exp:
+        await mongodb_handler.update_one(
+            Collection.USERS, {"_id": uid}, {"guest_auth": None}
+        )
         return None
 
     return auth.key

--- a/apps/api/src/auth/guest_auth.py
+++ b/apps/api/src/auth/guest_auth.py
@@ -88,9 +88,7 @@ async def _get_existing_key(email: EmailStr) -> Optional[str]:
     # Reject expired key
     now = utc_now()
     if now > auth.exp:
-        await mongodb_handler.update_one(
-            Collection.USERS, {"_id": uid}, {"guest_auth": None}
-        )
+        await _remove_expired_guest_key(uid)
         return None
 
     return auth.key
@@ -108,6 +106,12 @@ async def _remove_guest_key(uid: str) -> None:
         Collection.USERS,
         {"_id": uid},
         {"guest_auth": None, "last_login": utc_now()},
+    )
+
+
+async def _remove_expired_guest_key(uid: str) -> None:
+    await mongodb_handler.update_one(
+        Collection.USERS, {"_id": uid}, {"guest_auth": None}
     )
 
 

--- a/apps/api/src/auth/guest_auth.py
+++ b/apps/api/src/auth/guest_auth.py
@@ -88,7 +88,6 @@ async def _get_existing_key(email: EmailStr) -> Optional[str]:
     # Reject expired key
     now = utc_now()
     if now > auth.exp:
-        await _remove_guest_key(uid)
         return None
 
     return auth.key

--- a/apps/api/tests/test_guest_auth.py
+++ b/apps/api/tests/test_guest_auth.py
@@ -3,9 +3,11 @@ from datetime import datetime, timezone
 from unittest.mock import AsyncMock, patch
 
 from auth import guest_auth
+from services.mongodb_handler import Collection
 
 guest_auth.AUTH_KEY_SALT = "not-a-good-idea".encode()
 SAMPLE_EMAIL = "jeff@amazon.com"
+SAMPLE_UID = "com.amazon.jeff"
 
 
 @patch("services.mongodb_handler.retrieve_one", autospec=True)
@@ -73,7 +75,9 @@ async def test_expired_key_is_removed(
 
     key = await guest_auth._get_existing_key(SAMPLE_EMAIL)
     assert key is None
-    mock_mongodb_update_one.assert_awaited_once()
+    mock_mongodb_update_one.assert_awaited_once_with(
+        Collection.USERS, {"_id": SAMPLE_UID}, {"guest_auth": None}
+    )
 
 
 @patch("services.mongodb_handler.retrieve_one", autospec=True)


### PR DESCRIPTION
Resolves #178 by removing the call to `_remove_guest_key` in the `_get_existing_key` function.