### PR TITLE
Guest auth token is now removed only after successful verification

### DIFF
--- a/apps/api/src/auth/guest_auth.py
+++ b/apps/api/src/auth/guest_auth.py
@@ -58,7 +58,8 @@ async def initiate_guest_login(email: EmailStr) -> Optional[str]:
 async def verify_guest_credentials(
     email: EmailStr, passphrase: str, confirmation: str
 ) -> bool:
-    """Check that passphrase and confirmation are valid for the given user."""
+    """Check that passphrase and confirmation are valid for the given user and
+    remove the guest key upon successful validation."""
     key = await _get_existing_key(email)
     if not key:
         return False

--- a/apps/api/src/auth/guest_auth.py
+++ b/apps/api/src/auth/guest_auth.py
@@ -64,8 +64,10 @@ async def verify_guest_credentials(
         return False
 
     uid = user_identity.scoped_uid(email)
-    await _remove_guest_key(uid)
-    return _validate(key, passphrase, confirmation)
+    is_valid = _validate(key, passphrase, confirmation)
+    if is_valid:
+        await _remove_guest_key(uid)
+    return is_valid
 
 
 def acquire_guest_identity(email: EmailStr) -> GuestUser:

--- a/apps/api/tests/test_guest.py
+++ b/apps/api/tests/test_guest.py
@@ -109,9 +109,7 @@ def test_successful_guest_verification_provides_identity(
 
 
 @patch("auth.guest_auth._get_existing_key", autospec=True)
-@patch("auth.guest_auth._remove_guest_key", autospec=True)
 def test_invalid_guest_verification_is_unauthorized(
-    mock_remove_guest_key: AsyncMock,
     mock_get_existing_key: AsyncMock,
 ) -> None:
     """Test that a guest with invalid credentials is unauthorized."""
@@ -124,5 +122,3 @@ def test_invalid_guest_verification_is_unauthorized(
     )
 
     assert res.status_code == 401
-
-    mock_remove_guest_key.assert_awaited_once_with("edu.caltech.beaver")

--- a/apps/api/tests/test_guest.py
+++ b/apps/api/tests/test_guest.py
@@ -108,9 +108,11 @@ def test_successful_guest_verification_provides_identity(
     mock_remove_guest_key.assert_awaited_once_with("edu.caltech.beaver")
 
 
+@patch("auth.guest_auth._remove_guest_key", autospec=True)
 @patch("auth.guest_auth._get_existing_key", autospec=True)
 def test_invalid_guest_verification_is_unauthorized(
     mock_get_existing_key: AsyncMock,
+    mock_remove_guest_key: AsyncMock,
 ) -> None:
     """Test that a guest with invalid credentials is unauthorized."""
     mock_get_existing_key.return_value = "some-existing-key"
@@ -122,3 +124,5 @@ def test_invalid_guest_verification_is_unauthorized(
     )
 
     assert res.status_code == 401
+
+    mock_remove_guest_key.assert_not_awaited()


### PR DESCRIPTION
To resolve the issue pointed out in #182, we should remove the token only when the call to the `_validate` function returns `True`, or in other words, if the passphrase and confirmation are valid.