### PR TITLE
Add local-only dev route to simulate user identity

### DIFF
--- a/apps/api/docker-compose.yml
+++ b/apps/api/docker-compose.yml
@@ -1,5 +1,5 @@
 # Use root/example as user/password credentials
-version: "3.1"
+version: "3.4"
 
 services:
     mongo:
@@ -27,6 +27,7 @@ services:
             - "8000:8000"
         environment:
             MONGODB_URI: mongodb://root:example@mongo:27017
+            DEPLOYMENT: LOCAL
 
 volumes:
-    mongodb_data_volume:
+    mongodb_data_volume: {}

--- a/apps/api/src/app.py
+++ b/apps/api/src/app.py
@@ -1,6 +1,11 @@
+import logging
+import os
+
 from fastapi import FastAPI
 
-from routers import demo, guest, saml, user, admin
+from routers import admin, demo, guest, saml, user
+
+logging.basicConfig(level=logging.INFO)
 
 app = FastAPI()
 
@@ -9,6 +14,11 @@ app.include_router(demo.router, prefix="/demo", tags=["demo"])
 app.include_router(guest.router, prefix="/guest", tags=["guest"])
 app.include_router(user.router, prefix="/user", tags=["user"])
 app.include_router(admin.router, prefix="/admin", tags=["admin"])
+
+if os.getenv("DEPLOYMENT") == "LOCAL":
+    from routers import dev
+
+    app.include_router(dev.router, prefix="/dev")
 
 
 @app.get("/")

--- a/apps/api/src/routers/dev.py
+++ b/apps/api/src/routers/dev.py
@@ -1,0 +1,23 @@
+from fastapi import APIRouter
+from fastapi.responses import RedirectResponse
+
+from auth import user_identity
+from auth.user_identity import COOKIE_NAME, NativeUser
+
+router = APIRouter()
+
+
+@router.get("/impersonate/{ucinetid}")
+async def impersonate(ucinetid: str) -> RedirectResponse:
+    """Simulate a user identity during local development (does not require https)."""
+    user = NativeUser(
+        ucinetid=ucinetid,
+        display_name="Local Dev",
+        email="dev@irvinehacks.com",
+        affiliations=[],
+    )
+
+    res = RedirectResponse("/portal", status_code=303)
+    jwt_token = user_identity._generate_jwt_token(user)
+    res.set_cookie(COOKIE_NAME, jwt_token, max_age=4000, httponly=True)
+    return res

--- a/apps/api/tests/test_app.py
+++ b/apps/api/tests/test_app.py
@@ -1,0 +1,18 @@
+from fastapi.routing import APIRoute
+from fastapi.testclient import TestClient
+
+from app import app
+
+client = TestClient(app)
+
+
+def test_user_identity_accessible() -> None:
+    """The user identity route needed in many places should be accessible."""
+    res = client.get("/user/me")
+    assert res.status_code == 200
+
+
+def test_dev_routes_inaccessible_by_default() -> None:
+    """Dev routes must not be accessible by default."""
+    routes: list[APIRoute] = app.routes  # type: ignore[assignment]
+    assert not any(route.path.startswith("/dev/") for route in routes)

--- a/apps/api/tests/test_dev.py
+++ b/apps/api/tests/test_dev.py
@@ -1,0 +1,22 @@
+from fastapi.testclient import TestClient
+
+from auth import user_identity
+from routers import dev
+
+client = TestClient(dev.router)
+
+
+def test_impersonate() -> None:
+    """Test the dev token can provide a valid user identity."""
+    res = client.get("/impersonate/stuffed", follow_redirects=False)
+
+    assert res.status_code == 303
+    assert res.headers["location"] == "/portal"
+    set_cookie = res.headers["Set-Cookie"].split(";")[0]
+    cookie_name, cookie_value = set_cookie.split("=")
+    assert cookie_name == "irvinehacks_auth"
+
+    # Confirm identity is valid and decodable
+    identity = user_identity._decode_user_identity(cookie_value)
+    assert identity is not None
+    assert identity.uid == "edu.uci.stuffed"


### PR DESCRIPTION
Ahead of #185, adding a local-only development endpoint to simulate a super identity. This will be useful in more easily testing all portions of the site including the Apply page, Portal page, and Admin site.

Resolves #118.

## Changes
- Add dev router with `/impersonate` endpoint to simulate user identity
- Mount dev router to app only when `DEPLOYMENT` environment is `LOCAL`
  - Add environment variable to docker-compose file
- Include associated tests for dev router and mounting

## Testing
1. Run the API through Docker and the development server for the site (e.g. `pnpm run dev`)
2. Access the impersonation endpoint through the site proxy
    - e.g. `http://localhost:3000/api/dev/impersonate/boo`
3. Confirm a user identity is provided
    - Navbar should indicate the user is logged in (button should say **Log Out**)
    - If the associated user has submitted an application, the Portal page should be shown
    - Otherwise, the Application Preface should be shown