### PR TITLE
Redirect to /login on 401 in admin console and remove unrelated unused import

### DIFF
--- a/apps/site/src/app/(main)/apply/sections/ApplyConfirmation/ConfirmationDetails.tsx
+++ b/apps/site/src/app/(main)/apply/sections/ApplyConfirmation/ConfirmationDetails.tsx
@@ -1,6 +1,5 @@
 import Button from "@/lib/components/Button/Button";
 import styles from "./ConfirmationDetails.module.scss";
-import Link from "next/link";
 
 interface ConfirmationDetailsProps {
 	isLoggedIn: boolean;
@@ -15,15 +14,14 @@ export default async function ConfirmationDetails({
 		>
 			<h1 className={`${styles.header} text-5xl`}>Before Applying</h1>
 			<p className={`${styles.policy} text-lg`}>
-				By submitting an application for IrvineHacks 2024, I understand
-				that IrvineHacks will take place in person during the day from
-				January 26 to 28, and that IrvineHacks will not be providing
-				transportation or overnight accommodations. In addition, I
-				understand that I must check in at certain times on all three
-				event days in order to be eligible to win prizes. Lastly, I
-				acknowledge that I am currently a student enrolled in an
-				accredited high school, college, or university in the United
-				States and will be over the age of 18 by January 26th, 2024.
+				By submitting an application for IrvineHacks 2024, I understand that
+				IrvineHacks will take place in person during the day from January 26 to
+				28, and that IrvineHacks will not be providing transportation or
+				overnight accommodations. In addition, I understand that I must check in
+				at certain times on all three event days in order to be eligible to win
+				prizes. Lastly, I acknowledge that I am currently a student enrolled in
+				an accredited high school, college, or university in the United States
+				and will be over the age of 18 by January 26th, 2024.
 			</p>
 			<strong className="text-lg text-[#FF2222]">
 				Applications are due on January 14th, 2024 at 11:59PM PST.

--- a/apps/site/src/app/admin/layout/AdminLayout.tsx
+++ b/apps/site/src/app/admin/layout/AdminLayout.tsx
@@ -41,7 +41,7 @@ function AdminLayout({ children }: PropsWithChildren) {
 	return (
 		<SWRConfig
 			value={{
-				onError: (err, _) => {
+				onError: (err) => {
 					if (axios.isAxiosError(err)) {
 						router.push("/login");
 					}

--- a/apps/site/src/app/admin/layout/AdminLayout.tsx
+++ b/apps/site/src/app/admin/layout/AdminLayout.tsx
@@ -41,10 +41,12 @@ function AdminLayout({ children }: PropsWithChildren) {
 	return (
 		<SWRConfig
 			value={{
-				onError: (err) => {
+				shouldRetryOnError: (err) => {
 					if (axios.isAxiosError(err) && err.response?.status === 401) {
 						router.push("/login");
+						return false;
 					}
+					return true;
 				},
 			}}
 		>

--- a/apps/site/src/app/admin/layout/AdminLayout.tsx
+++ b/apps/site/src/app/admin/layout/AdminLayout.tsx
@@ -42,7 +42,7 @@ function AdminLayout({ children }: PropsWithChildren) {
 		<SWRConfig
 			value={{
 				onError: (err) => {
-					if (axios.isAxiosError(err)) {
+					if (axios.isAxiosError(err) && err.response?.status === 401) {
 						router.push("/login");
 					}
 				},


### PR DESCRIPTION
Resolves #201. Use [`SWRConfig`](https://swr.vercel.app/docs/error-handling#global-error-report) to provide a global error handler when receiving an `AxiosError`.

Using the `redirect` function from `next/navigation` to redirect to `/login` resulted in an error message that simply states `NEXT_REDIRECT`, which upon further investigation, can only be used in server components, not client ones. Thus, I switched to `useRouter` from `next/navigation` and replaced each use of `redirect` with `useRouter`, resolving the error.

I also included a very minor out of scope change in this PR to remove an unused import. This was previously causing ESLint checks to fail, although deployments still worked properly because that "failure" was only an error.

To test that the unused import warning no longer works:
1. Run `pnpm build` in the root directory of the project or in the `site` directory.

To test that the redirect works properly on local:
1. Impersonate yourself by accessing `/api/dev/impersonate/[some identifier]`
2. Submit an application
3. In the MongoDB UI (http://localhost:8081, add the `reviewer` role to the the document associated with your application. This will grant you access to the admin console locally.
4. Access the admin console and go to the page with the list of applicants. Then delete your authentication cookie and click on one of the applications (perhaps your own). An error should show in the console and you should be redirected to the login page.