### PR TITLE
Feature/native user records

### DIFF
--- a/apps/api/src/routers/saml.py
+++ b/apps/api/src/routers/saml.py
@@ -83,7 +83,7 @@ async def _get_saml_auth(req: Request) -> OneLogin_Saml2_Auth:
     return OneLogin_Saml2_Auth(request_data, old_settings=settings)
 
 
-async def _insert_native_record(user: NativeUser) -> None:
+async def _update_last_login(user: NativeUser) -> None:
     now = utc_now()
     await mongodb_handler.update_one(
         Collection.USERS, {"_id": user.uid}, {"last_login": now}, upsert=True
@@ -135,7 +135,7 @@ async def acs(req: Request) -> RedirectResponse:
         affiliations=affiliations,
     )
 
-    await _insert_native_record(user)
+    await _update_last_login(user)
 
     res = RedirectResponse("/portal", status_code=303)
     issue_user_identity(user, res)

--- a/apps/api/src/routers/saml.py
+++ b/apps/api/src/routers/saml.py
@@ -11,7 +11,8 @@ from onelogin.saml2.auth import OneLogin_Saml2_Auth
 from onelogin.saml2.settings import OneLogin_Saml2_Settings
 
 from auth.user_identity import NativeUser, utc_now, issue_user_identity
-from services.mongodb_handler import Collection, update_one
+from services import mongodb_handler
+from services.mongodb_handler import Collection
 
 log = getLogger(__name__)
 
@@ -84,7 +85,7 @@ async def _get_saml_auth(req: Request) -> OneLogin_Saml2_Auth:
 
 async def _insert_native_record(user: NativeUser) -> None:
     now = utc_now()
-    await update_one(
+    await mongodb_handler.update_one(
         Collection.USERS, {"_id": user.uid}, {"last_login": now}, upsert=True
     )
 


### PR DESCRIPTION
Resolves #179. This pull request creates a helper function in the `/acs` route function to [upsert](https://www.mongodb.com/docs/drivers/node/current/fundamentals/crud/write-operations/upsert/) a native user record containing a user's UID and last login time to the MongoDB database, updating unit tests as needed.

Testing this requires assigning this deployment's domain to `staging.irvinehacks.com`, logging in as a native user, and then checking the MongoDB staging database to see if a record has been properly upserted. I can take care of assigning the domain and viewing the staging database because only directors have access to these, so reviewers should simply access staging, log in via UCI SSO, and let me know.