### PR TITLE
update: sponsor zod validation schema

### DIFF
--- a/apps/site/src/app/(main)/(home)/sections/Sponsors/getSponsors.ts
+++ b/apps/site/src/app/(main)/(home)/sections/Sponsors/getSponsors.ts
@@ -3,17 +3,24 @@ import { cache } from "react";
 import { client } from "@/lib/sanity/client";
 import { SanityDocument, SanityImageReference } from "@/lib/sanity/types";
 
+export const Sponsor = z.object({
+	_type: z.literal("sponsor"),
+	_key: z.string(),
+	name: z.string(),
+	url: z.string().url().optional(),
+	tier: z.union([
+		z.literal("platinum"),
+		z.literal("gold"),
+		z.literal("bronze"),
+		z.literal("silver"),
+		z.literal("sponsored-prize"),
+		z.literal("in-kind"),
+	]),
+	logo: SanityImageReference,
+});
+
 const Sponsors = SanityDocument.extend({
-	sponsors: z.array(
-		z.object({
-			_type: z.literal("sponsor"),
-			_key: z.string(),
-			name: z.string(),
-			url: z.string().url().optional(),
-			tier: z.union([z.literal("bronze"), z.literal("silver")]),
-			logo: SanityImageReference,
-		}),
-	),
+	sponsors: z.array(Sponsor),
 });
 
 export const getSponsors = cache(async () => {


### PR DESCRIPTION
Resolves #213. Updating the sponsors to their proper tiers at this current moment will cause Zod to throw an error in production, making the site inaccessible. Thus, the Zod schema should be updated first before making any other changes in the frontend.

The main reason for extracting and creating a new `Sponsor` validation is for #210, in which I plan on separating the sponsors into a `Map` by tier in the `getSponsors` function and returning that map instead of just the list of sponsors.