### PR TITLE
Update/differentiate sponsor tiers

### DIFF
--- a/apps/site/src/app/(main)/(home)/sections/Sponsors/Sponsors.module.scss
+++ b/apps/site/src/app/(main)/(home)/sections/Sponsors/Sponsors.module.scss
@@ -1,3 +1,21 @@
 .title {
 	text-shadow: 0px 0px 20px rgba(255, 255, 255, 0.75);
 }
+
+@media (min-width: 1024px) {
+	.platinum,
+	.gold {
+		max-width: 400px;
+		max-height: 400px;
+	}
+	.silver {
+		max-width: 350px;
+		max-height: 350px;
+	}
+	.bronze,
+	.sponsored-prize,
+	.in-kind {
+		max-width: 300px;
+		max-height: 300px;
+	}
+}

--- a/apps/site/src/app/(main)/(home)/sections/Sponsors/Sponsors.tsx
+++ b/apps/site/src/app/(main)/(home)/sections/Sponsors/Sponsors.tsx
@@ -7,6 +7,15 @@ import SponsorTier from "./components/SponsorTier/SponsorTier";
 
 import styles from "./Sponsors.module.scss";
 
+const TIERS = [
+	"platinum",
+	"gold",
+	"silver",
+	"bronze",
+	"sponsored-prize",
+	"in-kind",
+];
+
 export default async function Sponsors() {
 	const sponsors = await getSponsors();
 
@@ -26,27 +35,11 @@ export default async function Sponsors() {
 				</a>
 				.
 			</p>
-			<SponsorTier
-				sponsors={sponsors.get("platinum")}
-				className={styles.platinum}
-			/>
-			<SponsorTier sponsors={sponsors.get("gold")} className={styles.gold} />
-			<SponsorTier
-				sponsors={sponsors.get("silver")}
-				className={styles.silver}
-			/>
-			<SponsorTier
-				sponsors={sponsors.get("bronze")}
-				className={styles.bronze}
-			/>
-			<SponsorTier
-				sponsors={sponsors.get("sponsored-prize")}
-				className={styles["sponsored-prize"]}
-			/>
-			<SponsorTier
-				sponsors={sponsors.get("in-kind")}
-				className={styles["in-kind"]}
-			/>
+			{TIERS.map((tier) => (
+				<div key={tier}>
+					<SponsorTier sponsors={sponsors.get(tier)} className={styles[tier]} />
+				</div>
+			))}
 			<Image src={fishingBoat} alt="boat" width="400" height="400" />
 		</section>
 	);

--- a/apps/site/src/app/(main)/(home)/sections/Sponsors/Sponsors.tsx
+++ b/apps/site/src/app/(main)/(home)/sections/Sponsors/Sponsors.tsx
@@ -26,12 +26,27 @@ export default async function Sponsors() {
 				</a>
 				.
 			</p>
-			<SponsorTier sponsors={sponsors.get("platinum")} maxWidth={500} />
-			<SponsorTier sponsors={sponsors.get("gold")} maxWidth={400} />
-			<SponsorTier sponsors={sponsors.get("silver")} maxWidth={300} />
-			<SponsorTier sponsors={sponsors.get("bronze")} maxWidth={200} />
-			<SponsorTier sponsors={sponsors.get("sponsored-prize")} maxWidth={200} />
-			<SponsorTier sponsors={sponsors.get("in-kind")} maxWidth={200} />
+			<SponsorTier
+				sponsors={sponsors.get("platinum")}
+				className={styles.platinum}
+			/>
+			<SponsorTier sponsors={sponsors.get("gold")} className={styles.gold} />
+			<SponsorTier
+				sponsors={sponsors.get("silver")}
+				className={styles.silver}
+			/>
+			<SponsorTier
+				sponsors={sponsors.get("bronze")}
+				className={styles.bronze}
+			/>
+			<SponsorTier
+				sponsors={sponsors.get("sponsored-prize")}
+				className={styles["sponsored-prize"]}
+			/>
+			<SponsorTier
+				sponsors={sponsors.get("in-kind")}
+				className={styles["in-kind"]}
+			/>
 			<Image src={fishingBoat} alt="boat" width="400" height="400" />
 		</section>
 	);

--- a/apps/site/src/app/(main)/(home)/sections/Sponsors/Sponsors.tsx
+++ b/apps/site/src/app/(main)/(home)/sections/Sponsors/Sponsors.tsx
@@ -2,13 +2,10 @@
 import Image from "next/image";
 
 import { getSponsors } from "./getSponsors";
-import { client } from "@/lib/sanity/client";
-import imageUrlBuilder from "@sanity/image-url";
 import fishingBoat from "@/assets/images/fishing-boat.png";
+import SponsorTier from "./components/SponsorTier/SponsorTier";
 
 import styles from "./Sponsors.module.scss";
-
-const builder = imageUrlBuilder(client);
 
 export default async function Sponsors() {
 	const sponsors = await getSponsors();
@@ -21,33 +18,20 @@ export default async function Sponsors() {
 				Sponsors
 			</h2>
 			<p className="max-w-md mb-12">
-				Interested in sponsoring IrvineHacks 2024? Check out our
-				information above to learn more about our event! For more
-				information, please email us at{" "}
-				<a
-					href="mailto:hack@uci.edu"
-					className="hover:underline font-bold"
-				>
+				Interested in sponsoring IrvineHacks 2024? Check out our information
+				above to learn more about our event! For more information, please email
+				us at{" "}
+				<a href="mailto:hack@uci.edu" className="hover:underline font-bold">
 					hack@uci.edu
 				</a>
 				.
 			</p>
-			<div className="grid grid-cols-1 md:grid-cols-2 gap-14 items-center mb-12">
-				{sponsors.sponsors.map(({ _key, name, url, logo }) => (
-					<a
-						key={_key}
-						href={url}
-						target="_blank"
-						rel="noopener noreferrer"
-					>
-						<img
-							className="w-full"
-							src={builder.image(logo).format("webp").url()}
-							alt={name + " logo"}
-						/>
-					</a>
-				))}
-			</div>
+			<SponsorTier sponsors={sponsors.get("platinum")} maxWidth={500} />
+			<SponsorTier sponsors={sponsors.get("gold")} maxWidth={400} />
+			<SponsorTier sponsors={sponsors.get("silver")} maxWidth={300} />
+			<SponsorTier sponsors={sponsors.get("bronze")} maxWidth={200} />
+			<SponsorTier sponsors={sponsors.get("sponsored-prize")} maxWidth={200} />
+			<SponsorTier sponsors={sponsors.get("in-kind")} maxWidth={200} />
 			<Image src={fishingBoat} alt="boat" width="400" height="400" />
 		</section>
 	);

--- a/apps/site/src/app/(main)/(home)/sections/Sponsors/components/SponsorTier/SponsorTier.tsx
+++ b/apps/site/src/app/(main)/(home)/sections/Sponsors/components/SponsorTier/SponsorTier.tsx
@@ -1,0 +1,26 @@
+import { z } from "zod";
+import imageUrlBuilder from "@sanity/image-url";
+import { client } from "@/lib/sanity/client";
+import { Sponsor } from "../../getSponsors";
+
+const builder = imageUrlBuilder(client);
+
+interface SponsorTierProps {
+	sponsors?: z.infer<typeof Sponsor>[];
+}
+
+export default function SponsorTier({ sponsors }: SponsorTierProps) {
+	return (
+		<div className="lg:flex m-10 lg:gap-10 items-center">
+			{sponsors?.map(({ _key, name, url, logo }) => (
+				<a key={_key} href={url} target="_blank" rel="noopener noreferrer">
+					<img
+						src={builder.image(logo).format("webp").url()}
+						alt={name + " logo"}
+						className="max-w-full max-h-full lg:max-w-[300px] lg:max-h-[300px] m-auto my-5"
+					/>
+				</a>
+			))}
+		</div>
+	);
+}

--- a/apps/site/src/app/(main)/(home)/sections/Sponsors/components/SponsorTier/SponsorTier.tsx
+++ b/apps/site/src/app/(main)/(home)/sections/Sponsors/components/SponsorTier/SponsorTier.tsx
@@ -6,18 +6,19 @@ import { Sponsor } from "../../getSponsors";
 const builder = imageUrlBuilder(client);
 
 interface SponsorTierProps {
+	className: string;
 	sponsors?: z.infer<typeof Sponsor>[];
 }
 
-export default function SponsorTier({ sponsors }: SponsorTierProps) {
+export default function SponsorTier({ className, sponsors }: SponsorTierProps) {
 	return (
-		<div className="lg:flex m-10 lg:gap-10 items-center">
+		<div className="xl:flex m-10 xl:gap-10 items-center">
 			{sponsors?.map(({ _key, name, url, logo }) => (
 				<a key={_key} href={url} target="_blank" rel="noopener noreferrer">
 					<img
 						src={builder.image(logo).format("webp").url()}
 						alt={name + " logo"}
-						className="max-w-full max-h-full lg:max-w-[300px] lg:max-h-[300px] m-auto my-5"
+						className={"max-w-full max-h-full m-auto my-5 " + className}
 					/>
 				</a>
 			))}

--- a/apps/site/src/app/(main)/(home)/sections/Sponsors/components/SponsorTier/SponsorTier.tsx
+++ b/apps/site/src/app/(main)/(home)/sections/Sponsors/components/SponsorTier/SponsorTier.tsx
@@ -12,9 +12,10 @@ interface SponsorTierProps {
 
 export default function SponsorTier({ className, sponsors }: SponsorTierProps) {
 	return (
-		<div className="xl:flex m-10 xl:gap-10 items-center">
+		<div className="xl:flex m-16 xl:gap-10 items-center">
 			{sponsors?.map(({ _key, name, url, logo }) => (
 				<a key={_key} href={url} target="_blank" rel="noopener noreferrer">
+					{/* eslint-disable-next-line @next/next/no-img-element*/}
 					<img
 						src={builder.image(logo).format("webp").url()}
 						alt={name + " logo"}

--- a/apps/site/src/app/(main)/(home)/sections/Sponsors/getSponsors.ts
+++ b/apps/site/src/app/(main)/(home)/sections/Sponsors/getSponsors.ts
@@ -2,7 +2,6 @@ import { z } from "zod";
 import { cache } from "react";
 import { client } from "@/lib/sanity/client";
 import { SanityDocument, SanityImageReference } from "@/lib/sanity/types";
-import { on } from "events";
 
 export const Sponsor = z.object({
 	_type: z.literal("sponsor"),

--- a/apps/site/src/app/(main)/(home)/sections/Sponsors/getSponsors.ts
+++ b/apps/site/src/app/(main)/(home)/sections/Sponsors/getSponsors.ts
@@ -2,6 +2,7 @@ import { z } from "zod";
 import { cache } from "react";
 import { client } from "@/lib/sanity/client";
 import { SanityDocument, SanityImageReference } from "@/lib/sanity/types";
+import { on } from "events";
 
 export const Sponsor = z.object({
 	_type: z.literal("sponsor"),
@@ -24,5 +25,13 @@ const Sponsors = SanityDocument.extend({
 });
 
 export const getSponsors = cache(async () => {
-	return Sponsors.parse(await client.fetch("*[_type == 'sponsors'][0]"));
+	const sponsorTiers = new Map<string, z.infer<typeof Sponsor>[]>();
+	const sponsors = Sponsors.parse(
+		await client.fetch("*[_type == 'sponsors'][0]"),
+	);
+	sponsors.sponsors.forEach((sponsor) => {
+		const { tier } = sponsor;
+		sponsorTiers.set(tier, [...(sponsorTiers.get(tier) ?? []), sponsor]);
+	});
+	return sponsorTiers;
 });


### PR DESCRIPTION
Resolves #210.

- Adjust `getSponsors` function to return sponsors partitioned into their tiers
- Alter frontend sponsors section to show logos based on highest to lowest tiers, ensuring that higher tier logos have larger images.