### PR TITLE
Provide endpoint to initiate waiver signing

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,31 @@
+{
+	// Use IntelliSense to learn about possible attributes.
+	// Hover to view descriptions of existing attributes.
+	// For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
+	"version": "0.2.0",
+	"configurations": [
+		{
+			"name": "Python: Current File",
+			"type": "python",
+			"request": "launch",
+			"program": "${file}",
+			"purpose": ["debug-in-terminal"],
+			"console": "integratedTerminal",
+			"cwd": "${workspaceFolder}/apps/api",
+			"env": { "PYTHONPATH": "src" },
+			"justMyCode": false
+		},
+		{
+			"name": "Python: Debug Test",
+			"type": "python",
+			"request": "launch",
+			"program": "${file}",
+			"purpose": ["debug-test"],
+			"console": "integratedTerminal",
+			"env": {
+				"PYTEST_ADDOPTS": "--no-cov"
+			},
+			"justMyCode": true
+		}
+	]
+}

--- a/apps/api/pyproject.toml
+++ b/apps/api/pyproject.toml
@@ -15,7 +15,7 @@ branch = true
 show_missing = true
 
 [tool.mypy]
-mypy_path = "src,stubs"
+mypy_path = "src,stubs,tests"
 explicit_package_bases = true
 strict = true
 plugins = ["pydantic.mypy"]

--- a/apps/api/src/services/docusign_handler.py
+++ b/apps/api/src/services/docusign_handler.py
@@ -1,0 +1,22 @@
+import urllib.parse
+
+from pydantic import EmailStr
+
+
+def waiver_form_url(email: EmailStr, user_name: str) -> str:
+    """Provide URL to DocuSign PowerForm for waiver with pre-filled user info."""
+    role_name = "Participant"
+    query = urllib.parse.urlencode(
+        {
+            "env": "demo",  # temporary
+            "PowerFormId": "d5120219-dec1-41c5-b579-5e6b45c886e8",  # temporary
+            "acct": "cc0e3157-358d-4e10-acb0-ef39db7e3071",  # temporary
+            f"{role_name}_Email": email,
+            f"{role_name}_UserName": user_name,
+            "v": "2",
+        }
+    )
+
+    return (
+        f"https://demo.docusign.net/Member/PowerFormSigning.aspx?{query}"  # temporary
+    )

--- a/apps/api/src/utils/user_record.py
+++ b/apps/api/src/utils/user_record.py
@@ -1,5 +1,5 @@
 from enum import Enum
-from typing import Union
+from typing import Literal, Union
 
 from pydantic import Field
 
@@ -20,6 +20,7 @@ class Role(str, Enum):
 class Status(str, Enum):
     PENDING_REVIEW = "PENDING_REVIEW"
     REVIEWED = "REVIEWED"
+    WAIVER_SIGNED = "WAIVER_SIGNED"
     CONFIRMED = "CONFIRMED"
 
 
@@ -29,6 +30,6 @@ class UserRecord(BaseRecord):
 
 
 class Applicant(UserRecord):
-    role: Role = Role.APPLICANT
+    role: Literal[Role.APPLICANT] = Role.APPLICANT
     status: Union[Status, Decision]
     application_data: ProcessedApplicationData

--- a/apps/api/tests/test_authorization.py
+++ b/apps/api/tests/test_authorization.py
@@ -1,0 +1,82 @@
+from datetime import datetime
+from unittest.mock import AsyncMock, patch
+
+import pytest
+from fastapi.exceptions import HTTPException
+from test_user_apply import SAMPLE_APPLICATION
+
+from auth import authorization
+from auth.user_identity import GuestUser, User
+from models.ApplicationData import Decision
+from utils.user_record import Role
+
+
+@patch("services.mongodb_handler.retrieve_one", autospec=True)
+async def test_guest_without_role_is_unapplied(
+    mock_mongodb_handler_retrieve_one: AsyncMock,
+) -> None:
+    """User without status or role is not considered applicant."""
+    mock_mongodb_handler_retrieve_one.return_value = {
+        "_id": "edu.stanford.tree",
+    }
+
+    with pytest.raises(HTTPException) as excinfo:
+        await authorization.require_accepted_applicant(
+            GuestUser(email="tree@stanford.edu")
+        )
+    assert "403" in str(excinfo.value)
+
+
+@patch("services.mongodb_handler.retrieve_one", autospec=True)
+async def test_rejected_applicant_is_unapplied(
+    mock_mongodb_handler_retrieve_one: AsyncMock,
+) -> None:
+    """User with applicant role and rejected status is not accepted."""
+    mock_mongodb_handler_retrieve_one.return_value = {
+        "_id": "edu.ucsd.tritons",
+        "status": Decision.REJECTED,
+        "role": Role.APPLICANT,
+        "application_data": {**SAMPLE_APPLICATION, "submission_time": datetime.now()},
+    }
+
+    with pytest.raises(HTTPException) as excinfo:
+        await authorization.require_accepted_applicant(
+            GuestUser(email="tritons@ucsd.edu")
+        )
+    assert "403" in str(excinfo.value)
+
+
+@patch("services.mongodb_handler.retrieve_one", autospec=True)
+async def test_accepted_applicant_is_fine(
+    mock_mongodb_handler_retrieve_one: AsyncMock,
+) -> None:
+    """User with applicant role and accepted status is fine."""
+    mock_mongodb_handler_retrieve_one.return_value = {
+        "_id": "edu.berkeley.oski",
+        "status": Decision.ACCEPTED,
+        "role": Role.APPLICANT,
+        "application_data": {**SAMPLE_APPLICATION, "submission_time": datetime.now()},
+    }
+
+    user, applicant = await authorization.require_accepted_applicant(
+        GuestUser(email="oski@berkeley.edu")
+    )
+    assert user.uid == "edu.berkeley.oski"
+    assert applicant.status == Decision.ACCEPTED
+
+
+@patch("services.mongodb_handler.retrieve_one", autospec=True)
+async def test_non_applicant_is_unapplied(
+    mock_mongodb_handler_retrieve_one: AsyncMock,
+) -> None:
+    """User with other role is not considered applicant."""
+    mock_mongodb_handler_retrieve_one.return_value = {
+        "_id": "edu.uci.hack",
+        "role": Role.DIRECTOR,
+    }
+
+    with pytest.raises(HTTPException) as excinfo:
+        await authorization.require_accepted_applicant(
+            User(uid="hack", email="hack@uci.edu")
+        )
+    assert "403" in str(excinfo.value)

--- a/apps/api/tests/test_user.py
+++ b/apps/api/tests/test_user.py
@@ -1,16 +1,11 @@
-from datetime import datetime
 from unittest.mock import AsyncMock, patch
 
 from fastapi import FastAPI, status
 from fastapi.testclient import TestClient
-from test_user_apply import SAMPLE_APPLICATION
 
-from auth.authorization import require_accepted_applicant
-from auth.user_identity import GuestUser, User, UserTestClient
-from models.ApplicationData import Decision
+from auth.user_identity import GuestUser, UserTestClient
 from routers import user
 from services.mongodb_handler import Collection
-from utils.user_record import Applicant, Role, Status
 
 app = FastAPI()
 app.include_router(user.router)
@@ -63,54 +58,3 @@ def test_plain_identity_when_no_user_record(
     )
     data = res.json()
     assert data == {"uid": "edu.stanford.tree", "status": None, "role": None}
-
-
-def test_accepted_user_can_request_waiver() -> None:
-    """Test accepted applicant can request signing waiver."""
-    uid = "edu.uci.hack"
-    app.dependency_overrides[require_accepted_applicant] = lambda: (
-        User(uid=uid, email="hack@uci.edu"),
-        Applicant(
-            uid=uid,
-            role=Role.APPLICANT,
-            status=Decision.ACCEPTED,
-            application_data={
-                **SAMPLE_APPLICATION,  # type: ignore[arg-type]
-                "submission_time": datetime.now(),
-                "first_name": "Riley",
-                "last_name": "Wong",
-            },
-        ),
-    )
-
-    res = client.get("/waiver", follow_redirects=False)
-
-    assert res.status_code == 303
-    location = res.headers["location"]
-    assert "docusign" in location
-    assert "Participant_Email=hack%40uci.edu" in location
-    assert "Participant_UserName=Riley+Wong" in location
-
-    app.dependency_overrides = {}
-
-
-def test_cannot_request_waiver_if_already_signed() -> None:
-    """Test applicant who already signed waiver cannot re-request signing."""
-    uid = "edu.uci.hack"
-    app.dependency_overrides[require_accepted_applicant] = lambda: (
-        User(uid=uid, email="hack@uci.edu"),
-        Applicant(
-            uid="edu.uci.hack",
-            role=Role.APPLICANT,
-            status=Status.WAIVER_SIGNED,
-            application_data={
-                **SAMPLE_APPLICATION,  # type: ignore[arg-type]
-                "submission_time": datetime.now(),
-            },
-        ),
-    )
-
-    res = client.get("/waiver")
-    assert res.status_code == 403
-
-    app.dependency_overrides = {}

--- a/apps/api/tests/test_user.py
+++ b/apps/api/tests/test_user.py
@@ -1,11 +1,16 @@
+from datetime import datetime
 from unittest.mock import AsyncMock, patch
 
 from fastapi import FastAPI, status
 from fastapi.testclient import TestClient
+from test_user_apply import SAMPLE_APPLICATION
 
-from auth.user_identity import GuestUser, UserTestClient
+from auth.authorization import require_accepted_applicant
+from auth.user_identity import GuestUser, User, UserTestClient
+from models.ApplicationData import Decision
 from routers import user
 from services.mongodb_handler import Collection
+from utils.user_record import Applicant, Role, Status
 
 app = FastAPI()
 app.include_router(user.router)
@@ -58,3 +63,54 @@ def test_plain_identity_when_no_user_record(
     )
     data = res.json()
     assert data == {"uid": "edu.stanford.tree", "status": None, "role": None}
+
+
+def test_accepted_user_can_request_waiver() -> None:
+    """Test accepted applicant can request signing waiver."""
+    uid = "edu.uci.hack"
+    app.dependency_overrides[require_accepted_applicant] = lambda: (
+        User(uid=uid, email="hack@uci.edu"),
+        Applicant(
+            uid=uid,
+            role=Role.APPLICANT,
+            status=Decision.ACCEPTED,
+            application_data={
+                **SAMPLE_APPLICATION,  # type: ignore[arg-type]
+                "submission_time": datetime.now(),
+                "first_name": "Riley",
+                "last_name": "Wong",
+            },
+        ),
+    )
+
+    res = client.get("/waiver", follow_redirects=False)
+
+    assert res.status_code == 303
+    location = res.headers["location"]
+    assert "docusign" in location
+    assert "Participant_Email=hack%40uci.edu" in location
+    assert "Participant_UserName=Riley+Wong" in location
+
+    app.dependency_overrides = {}
+
+
+def test_cannot_request_waiver_if_already_signed() -> None:
+    """Test applicant who already signed waiver cannot re-request signing."""
+    uid = "edu.uci.hack"
+    app.dependency_overrides[require_accepted_applicant] = lambda: (
+        User(uid=uid, email="hack@uci.edu"),
+        Applicant(
+            uid="edu.uci.hack",
+            role=Role.APPLICANT,
+            status=Status.WAIVER_SIGNED,
+            application_data={
+                **SAMPLE_APPLICATION,  # type: ignore[arg-type]
+                "submission_time": datetime.now(),
+            },
+        ),
+    )
+
+    res = client.get("/waiver")
+    assert res.status_code == 403
+
+    app.dependency_overrides = {}

--- a/apps/api/tests/test_user_waiver.py
+++ b/apps/api/tests/test_user_waiver.py
@@ -1,0 +1,67 @@
+from datetime import datetime
+
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+from test_user_apply import SAMPLE_APPLICATION
+
+from auth.authorization import require_accepted_applicant
+from auth.user_identity import User
+from models.ApplicationData import Decision
+from routers import user
+from utils.user_record import Applicant, Role, Status
+
+app = FastAPI()
+app.include_router(user.router)
+
+client = TestClient(app)
+
+
+def test_accepted_user_can_request_waiver() -> None:
+    """Test accepted applicant can request signing waiver."""
+    uid = "edu.uci.hack"
+    app.dependency_overrides[require_accepted_applicant] = lambda: (
+        User(uid=uid, email="hack@uci.edu"),
+        Applicant(
+            uid=uid,
+            role=Role.APPLICANT,
+            status=Decision.ACCEPTED,
+            application_data={
+                **SAMPLE_APPLICATION,  # type: ignore[arg-type]
+                "submission_time": datetime.now(),
+                "first_name": "Riley",
+                "last_name": "Wong",
+            },
+        ),
+    )
+
+    res = client.get("/waiver", follow_redirects=False)
+
+    assert res.status_code == 303
+    location = res.headers["location"]
+    assert "docusign.net" in location
+    assert "Participant_Email=hack%40uci.edu" in location
+    assert "Participant_UserName=Riley+Wong" in location
+
+    app.dependency_overrides = {}
+
+
+def test_cannot_request_waiver_if_already_signed() -> None:
+    """Test applicant who already signed waiver cannot re-request signing."""
+    uid = "edu.uci.hack"
+    app.dependency_overrides[require_accepted_applicant] = lambda: (
+        User(uid=uid, email="hack@uci.edu"),
+        Applicant(
+            uid="edu.uci.hack",
+            role=Role.APPLICANT,
+            status=Status.WAIVER_SIGNED,
+            application_data={
+                **SAMPLE_APPLICATION,  # type: ignore[arg-type]
+                "submission_time": datetime.now(),
+            },
+        ),
+    )
+
+    res = client.get("/waiver")
+    assert res.status_code == 403
+
+    app.dependency_overrides = {}


### PR DESCRIPTION
Closes #217.

## Changes
- Add `/user/waiver` route to redirect to DocuSign waiver
- Create `require_accepted_application` dependency to allow only accepted applicants
- Add new `WAIVER_SIGNED` status
- Include VSCode PyTest configuration
- Unit tests for all the above

## Testing
1. Set the `DEPLOYMENT` environment variable to `LOCAL`.
2. Start the backend by running `pnpm dev` inside `apps/api`.
3. Create authentication cookie by accessing `http://localhost:8000/dev/impersonate/<ucinetid>`.
4. Complete an application.
5. Navigate to `http://localhost:8000/user/waiver` and you should be redirected to the DocuSign form. If you instead see a DocuSign prompt asking for your name and/or email, please indicate in review.

**Note:** We'll eventually need to update the PowerForm, Account ID, and other DocuSign related information, but we can do that in a separate issue.