### PR TITLE
Display UID in cards for Applicants on Admin site

### DIFF
--- a/apps/site/src/app/admin/applicants/Applicants.tsx
+++ b/apps/site/src/app/admin/applicants/Applicants.tsx
@@ -48,6 +48,11 @@ function Applicants() {
 				header: CardHeader,
 				sections: [
 					{
+						id: "uid",
+						header: "UID",
+						content: ({ _id }) => _id,
+					},
+					{
 						id: "school",
 						header: "School",
 						content: ({ application_data }) => application_data.school,


### PR DESCRIPTION
Show applicant UIDs in the cards view for Applicants on the Admin site.
<img src="https://github.com/HackAtUCI/irvinehacks-site-2024/assets/44419552/ab935a4c-a33c-4ee9-93e2-130558f080d4" alt="Sample view of applicant card showing name, uid, school, status, applied date, and decision" width=305 />