### PR TITLE
Override application deadline in `test_user_apply`

### DIFF
--- a/apps/api/tests/test_user_apply.py
+++ b/apps/api/tests/test_user_apply.py
@@ -1,4 +1,4 @@
-from datetime import datetime
+from datetime import datetime, timezone
 from unittest.mock import AsyncMock, Mock, patch
 
 import bson
@@ -12,6 +12,10 @@ from routers import user
 from services.mongodb_handler import Collection
 from utils import resume_handler
 from utils.user_record import Applicant, Status
+
+# Tests will break again next year, tech should notice and fix :P
+TEST_DEADLINE = datetime(2024, 10, 1, 8, 0, 0, tzinfo=timezone.utc)
+user.DEADLINE = TEST_DEADLINE
 
 USER_EMAIL = "pkfire@uci.edu"
 USER_PKFIRE = NativeUser(
@@ -45,7 +49,7 @@ EMPTY_RESUME = ("", b"", "application/octet-stream")
 
 EXPECTED_RESUME_UPLOAD = ("pk-fire-69f2afc2.pdf", b"resume", "application/pdf")
 SAMPLE_RESUME_URL = HttpUrl("https://drive.google.com/file/d/...")
-SAMPLE_SUBMISSION_TIME = datetime(2023, 1, 12, 8, 1, 21)
+SAMPLE_SUBMISSION_TIME = datetime(2023, 1, 12, 8, 1, 21, tzinfo=timezone.utc)
 SAMPLE_VERDICT_TIME = None
 
 EXPECTED_APPLICATION_DATA = ProcessedApplicationData(
@@ -84,7 +88,6 @@ client = UserTestClient(USER_PKFIRE, app)
 
 @patch("utils.email_handler.send_application_confirmation_email", autospec=True)
 @patch("services.mongodb_handler.update_one", autospec=True)
-@patch("routers.user._is_past_deadline", autospec=True)
 @patch("routers.user.datetime", autospec=True)
 @patch("services.gdrive_handler.upload_file", autospec=True)
 @patch("services.mongodb_handler.retrieve_one", autospec=True)
@@ -92,7 +95,6 @@ def test_apply_successfully(
     mock_mongodb_handler_retrieve_one: AsyncMock,
     mock_gdrive_handler_upload_file: AsyncMock,
     mock_datetime: Mock,
-    mock_is_past_deadline: Mock,
     mock_mongodb_handler_update_one: AsyncMock,
     mock_send_application_confirmation_email: AsyncMock,
 ) -> None:
@@ -100,7 +102,6 @@ def test_apply_successfully(
     mock_mongodb_handler_retrieve_one.return_value = None
     mock_gdrive_handler_upload_file.return_value = SAMPLE_RESUME_URL
     mock_datetime.now.return_value = SAMPLE_SUBMISSION_TIME
-    mock_is_past_deadline.return_value = False
     res = client.post("/apply", data=SAMPLE_APPLICATION, files=SAMPLE_FILES)
 
     mock_gdrive_handler_upload_file.assert_awaited_once_with(
@@ -280,10 +281,11 @@ def test_application_data_with_other_throws_422(
     assert res.status_code == 422
 
 
-@patch("routers.user._is_past_deadline", autospec=True)
-def test_past_deadline_throws_403(
-    mock_is_past_deadline: Mock,
-) -> None:
-    mock_is_past_deadline.return_value = True
+def test_past_deadline_causes_403() -> None:
+    """Test that users are forbidden from submitting applications past the deadline."""
+    user.DEADLINE = datetime(2023, 12, 18, 20, 0, 0, tzinfo=timezone.utc)
+
     res = client.post("/apply", data=SAMPLE_APPLICATION, files=SAMPLE_FILES)
     assert res.status_code == 403
+
+    user.DEADLINE = TEST_DEADLINE


### PR DESCRIPTION
Overrides deadline in User router during unit tests. This will break again next year as reminder for tech to pay attention to things going on. Fixes #232.