### PR TITLE
Add `waived` status to `PortalStatus`

### DIFF
--- a/apps/site/src/app/(main)/portal/@applicant/ApplicantPortal.tsx
+++ b/apps/site/src/app/(main)/portal/@applicant/ApplicantPortal.tsx
@@ -11,6 +11,7 @@ export const enum PortalStatus {
 	accepted = "ACCEPTED",
 	rejected = "REJECTED",
 	waitlisted = "WAITLISTED",
+	waived = "WAIVER_SIGNED",
 	confirmed = "CONFIRMED",
 }
 

--- a/apps/site/src/app/(main)/portal/@applicant/Message.tsx
+++ b/apps/site/src/app/(main)/portal/@applicant/Message.tsx
@@ -40,6 +40,7 @@ function Message({ status }: MessageProps) {
 				seeing you at IrvineHacks!
 			</p>
 		),
+		[PortalStatus.waived]: <></>,
 		[PortalStatus.confirmed]: <></>,
 	};
 


### PR DESCRIPTION
Following from #223 and as part of #221.
- Include new enum value: `PortalStatus.waived = "WAIVER_SIGNED"`
- Add empty Portal Message for waived status