### PR TITLE
Set up DocuSign webhook handler for waivers

### DIFF
--- a/apps/api/README.md
+++ b/apps/api/README.md
@@ -16,14 +16,19 @@ which will start a Uvicorn server with auto-reload.
 
 For deployment, the following environment variables need to be set:
 
--   `PYTHONPATH=src/api` to properly import Python modules
--   `SP_KEY`, the private key for SAML authentication
--   `JWT_KEY`, the secret key used to sign JWTs
--   `AUTH_KEY_SALT`, the salt used when encrypting guest authentication tokens
--   `SENDGRID_API_KEY`, the API key needed to use the SendGrid API
--   `RESUMES_FOLDER_ID`, the ID of the Google Drive folder to upload to
--   Either `SERVICE_ACCOUNT_FILE` or `GOOGLE_SERVICE_ACCOUNT_CREDENTIALS`: We use a Google service acccount in tandem with aiogoogle to automatically upload resumes when submitting a form. The keys are JSON that can either be stored in a file, in which case the path of the file should be stored in `SERVICE_ACCOUNT_FILE`, or be stored directly in `GOOGLE_SERVICE_ACCOUNT_CREDENTIALS`. For local development, it is recommended to take the `SERVICE_ACCOUNT_FILE` approach.
+- `PYTHONPATH=src/api` to properly import Python modules
+- `SP_KEY`, the private key for SAML authentication
+- `JWT_KEY`, the secret key used to sign JWTs
+- `AUTH_KEY_SALT`, the salt used when encrypting guest authentication tokens
+- `SENDGRID_API_KEY`, the API key needed to use the SendGrid API
+- `RESUMES_FOLDER_ID`, the ID of the Google Drive folder to upload to
+- Either `SERVICE_ACCOUNT_FILE` or `GOOGLE_SERVICE_ACCOUNT_CREDENTIALS`: We use a Google service acccount in tandem with aiogoogle to automatically upload resumes when submitting a form. The keys are JSON that can either be stored in a file, in which case the path of the file should be stored in `SERVICE_ACCOUNT_FILE`, or be stored directly in `GOOGLE_SERVICE_ACCOUNT_CREDENTIALS`. For local development, it is recommended to take the `SERVICE_ACCOUNT_FILE` approach.
+- `DOCUSIGN_HMAC_KEY`, the HMAC key for validating DocuSign Connect webhook event payloads.
 
 For staging, the following environment variables should also bet set:
 
--   `DEPLOYMENT=staging`
+- `DEPLOYMENT=staging`
+
+For local, the following environment variables should also be set:
+
+- `DEPLOYMENT=local`

--- a/apps/api/index.py
+++ b/apps/api/index.py
@@ -5,11 +5,14 @@ from fastapi import FastAPI
 from app import app as api
 from auth.guest_auth import AUTH_KEY_SALT
 from auth.user_identity import JWT_SECRET
+from services.docusign_handler import DOCUSIGN_HMAC_KEY
 
 if not JWT_SECRET:
     raise RuntimeError("JWT_SECRET is not defined")
 if not AUTH_KEY_SALT:
     raise RuntimeError("AUTH_KEY_SALT is not defined")
+if not DOCUSIGN_HMAC_KEY:
+    raise RuntimeError("DOCUSIGN_HMAC_KEY is not defined")
 
 # Override AWS Lambda logging configuration
 logging.basicConfig(level=logging.INFO, force=True)

--- a/apps/api/src/services/docusign_handler.py
+++ b/apps/api/src/services/docusign_handler.py
@@ -1,6 +1,56 @@
+import base64
+import hashlib
+import hmac
+import os
 import urllib.parse
+from datetime import datetime
+from logging import getLogger
+from typing import Sequence
+from uuid import UUID
 
-from pydantic import EmailStr
+from pydantic import UUID4, BaseModel, EmailStr
+
+from auth import user_identity
+from utils import waiver_handler
+
+log = getLogger(__name__)
+
+
+class PowerForm(BaseModel):
+    powerFormId: UUID4
+
+
+class Signer(BaseModel):
+    name: str
+    email: EmailStr
+
+
+class Recipients(BaseModel):
+    signers: list[Signer]
+
+
+class EnvelopeSummary(BaseModel):
+    status: str
+    recipients: Recipients
+    powerForm: PowerForm
+    completedDateTime: datetime
+
+
+class EnvelopeCompletedData(BaseModel):
+    accountId: UUID4
+    userId: UUID4
+    envelopeId: UUID4
+    envelopeSummary: EnvelopeSummary
+
+
+class WebhookPayload(BaseModel):
+    event: str
+    data: EnvelopeCompletedData
+
+
+DOCUSIGN_HMAC_KEY = os.getenv("DOCUSIGN_HMAC_KEY", "")
+POWERFORM_ID = UUID("d5120219-dec1-41c5-b579-5e6b45c886e8")  # temporary
+ACCOUNT_ID = UUID("cc0e3157-358d-4e10-acb0-ef39db7e3071")  # temporary
 
 
 def waiver_form_url(email: EmailStr, user_name: str) -> str:
@@ -9,8 +59,8 @@ def waiver_form_url(email: EmailStr, user_name: str) -> str:
     query = urllib.parse.urlencode(
         {
             "env": "demo",  # temporary
-            "PowerFormId": "d5120219-dec1-41c5-b579-5e6b45c886e8",  # temporary
-            "acct": "cc0e3157-358d-4e10-acb0-ef39db7e3071",  # temporary
+            "PowerFormId": str(POWERFORM_ID),
+            "acct": str(ACCOUNT_ID),
             f"{role_name}_Email": email,
             f"{role_name}_UserName": user_name,
             "v": "2",
@@ -20,3 +70,46 @@ def waiver_form_url(email: EmailStr, user_name: str) -> str:
     return (
         f"https://demo.docusign.net/Member/PowerFormSigning.aspx?{query}"  # temporary
     )
+
+
+def verify_webhook_signature(payload: bytes, signature: str) -> bool:
+    """Verify POST request content is signed according to the secret key."""
+    hmac_hash = hmac.new(DOCUSIGN_HMAC_KEY.encode(), payload, hashlib.sha256)
+    result = base64.b64encode(hmac_hash.digest())
+    return hmac.compare_digest(result, signature.encode())
+
+
+async def process_webhook_event(payload: WebhookPayload) -> None:
+    """Process webhook event from DocuSign for waiver signing."""
+    envelope_summary = payload.data.envelopeSummary
+    signers = envelope_summary.recipients.signers
+    _verify_envelope_content(envelope_summary.powerForm, signers)
+
+    email = signers[0].email
+    uid = _acquire_uid(email)
+
+    await waiver_handler.process_waiver_completion(uid, email)
+
+
+def _verify_envelope_content(power_form: PowerForm, signers: Sequence[Signer]) -> None:
+    """Raises ValueError if envelope data is invalid."""
+    # checked template id
+    if power_form.powerFormId != POWERFORM_ID:
+        log.error("Received DocuSign event for an unexpected PowerForm ID.")
+        raise ValueError("PowerForm IDs do not match")
+
+    # parse applicant from recipient
+    if len(signers) != 1:
+        log.error("DocuSign envelope had multiple signers.")
+        raise ValueError("PowerForm should only contain one signer")
+
+
+def _acquire_uid(email: EmailStr) -> str:
+    """Get UID from the user's email address."""
+    if user_identity.uci_email(email):
+        # Note: this is technically not correct since could have custom email,
+        # but most users have email addresses based on their UCInetID
+        ucinetid, _ = email.split("@")
+        return f"edu.uci.{ucinetid}"
+    else:
+        return user_identity.scoped_uid(email)

--- a/apps/api/src/services/mongodb_handler.py
+++ b/apps/api/src/services/mongodb_handler.py
@@ -7,7 +7,7 @@ from typing import Any, Mapping, Optional, Union
 from bson import CodecOptions
 from motor.core import AgnosticClient
 from motor.motor_asyncio import AsyncIOMotorClient
-from pydantic import BaseModel, Field, ConfigDict
+from pydantic import BaseModel, ConfigDict, Field
 
 log = getLogger(__name__)
 

--- a/apps/api/src/utils/waiver_handler.py
+++ b/apps/api/src/utils/waiver_handler.py
@@ -1,0 +1,48 @@
+from logging import getLogger
+
+from pydantic import EmailStr
+
+from models.ApplicationData import Decision
+from services import mongodb_handler
+from services.mongodb_handler import Collection
+from utils.user_record import Applicant, Role, Status, UserRecord
+
+log = getLogger(__name__)
+
+
+async def process_waiver_completion(uid: str, email: EmailStr) -> None:
+    """
+    Update user record with WAIVER_SIGNED status if the user is filling out the
+    waiver for the first time and if the user has a status of ACCEPTED.
+
+    If no user record exists, insert a new record. In all other cases, ignore
+    the submission.
+    """
+    record = await mongodb_handler.retrieve_one(Collection.USERS, {"_id": uid})
+
+    if not record:
+        # external participant, create database record
+        log.info(f"external participant {email} signed waiver.")
+        await mongodb_handler.insert(
+            Collection.USERS, {"_id": uid, "status": Status.WAIVER_SIGNED}
+        )
+        return
+
+    user_record = UserRecord.model_validate(record)
+    if user_record.role == Role.APPLICANT:
+        applicant_record = Applicant.model_validate(record)
+        if applicant_record.status in (Status.WAIVER_SIGNED, Status.CONFIRMED):
+            log.warning(
+                f"User {uid} attempted to sign waiver but already signed it previously."
+            )
+            return
+        elif applicant_record.status != Decision.ACCEPTED:
+            log.warning(f"User {uid} attempted to sign waiver but was not accepted.")
+            return
+
+    log.info(f"User {uid} signed waiver.")
+    # Note: this should be able to account for other participant types
+    # including mentors, volunteers, etc.
+    await mongodb_handler.update_one(
+        Collection.USERS, {"_id": uid}, {"status": Status.WAIVER_SIGNED}
+    )

--- a/apps/api/tests/test_docusign_handler.py
+++ b/apps/api/tests/test_docusign_handler.py
@@ -1,0 +1,120 @@
+from unittest.mock import AsyncMock, patch
+
+from test_user_apply import EXPECTED_APPLICATION_DATA
+
+from models.ApplicationData import Decision
+from services import docusign_handler
+from services.docusign_handler import ACCOUNT_ID, POWERFORM_ID, WebhookPayload
+from services.mongodb_handler import Collection
+from utils.user_record import Role, Status
+
+SAMPLE_WEBHOOK_PAYLOAD = {
+    "event": "envelope-completed",
+    "data": {
+        "accountId": str(ACCOUNT_ID),
+        "userId": "bc820e37-b38b-4dba-9650-139c3ae5e89c",  # fake
+        "envelopeId": "d5e52004-450c-41a4-99da-761d52c3876b",  # fake
+        "envelopeSummary": {
+            "status": "completed",
+            "completedDateTime": "1776-08-02T19:38:11.06Z",
+            "recipients": {
+                "signers": [
+                    {
+                        "name": "John Hancock",
+                        "email": "john@founders.gov",
+                    }
+                ],
+            },
+            "powerForm": {
+                "powerFormId": str(POWERFORM_ID),
+            },
+        },
+    },
+}
+
+SAMPLE_WEBHOOK_DATA = WebhookPayload.model_validate(SAMPLE_WEBHOOK_PAYLOAD)
+SAMPLE_UID = "gov.founders.john"
+
+
+@patch("services.mongodb_handler.update_one")
+@patch("services.mongodb_handler.retrieve_one")
+async def test_new_waiver_submission_can_be_processed(
+    mock_mongodb_handler_retrieve_one: AsyncMock,
+    mock_mongodb_handler_update_one: AsyncMock,
+) -> None:
+    """Waiver signing event from accepted participant can be processed properly."""
+    mock_mongodb_handler_retrieve_one.return_value = {
+        "_id": SAMPLE_UID,
+        "role": Role.APPLICANT,
+        "status": Decision.ACCEPTED,
+        "application_data": EXPECTED_APPLICATION_DATA,
+    }
+    await docusign_handler.process_webhook_event(SAMPLE_WEBHOOK_DATA)
+    mock_mongodb_handler_update_one.assert_awaited_once_with(
+        Collection.USERS, {"_id": SAMPLE_UID}, {"status": Status.WAIVER_SIGNED}
+    )
+
+
+@patch("services.mongodb_handler.update_one", autospec=True)
+@patch("services.mongodb_handler.retrieve_one", autospec=True)
+async def test_no_op_when_user_already_signed_waiver(
+    mock_mongodb_handler_retrieve_one: AsyncMock,
+    mock_mongodb_handler_update_one: AsyncMock,
+) -> None:
+    """If user has already signed waiver, ignore so RSVP status is maintained."""
+    mock_mongodb_handler_retrieve_one.return_value = {
+        "_id": SAMPLE_UID,
+        "role": Role.APPLICANT,
+        "status": Status.CONFIRMED,
+        "application_data": EXPECTED_APPLICATION_DATA,
+    }
+    await docusign_handler.process_webhook_event(SAMPLE_WEBHOOK_DATA)
+    mock_mongodb_handler_update_one.assert_not_awaited()
+
+
+@patch("services.mongodb_handler.update_one", autospec=True)
+@patch("services.mongodb_handler.retrieve_one", autospec=True)
+async def test_no_op_for_rejected_applicant(
+    mock_mongodb_handler_retrieve_one: AsyncMock,
+    mock_mongodb_handler_update_one: AsyncMock,
+) -> None:
+    """If applicant was not accepted, ignore waiv.r signing"""
+    mock_mongodb_handler_retrieve_one.return_value = {
+        "_id": SAMPLE_UID,
+        "role": Role.APPLICANT,
+        "status": Decision.REJECTED,
+        "application_data": EXPECTED_APPLICATION_DATA,
+    }
+    await docusign_handler.process_webhook_event(SAMPLE_WEBHOOK_DATA)
+    mock_mongodb_handler_update_one.assert_not_awaited()
+
+
+@patch("services.mongodb_handler.insert", autospec=True)
+@patch("services.mongodb_handler.retrieve_one", autospec=True)
+async def test_new_user_record_when_unknown_external_participant_signs_waiver(
+    mock_mongodb_handler_retrieve_one: AsyncMock,
+    mock_mongodb_handler_insert: AsyncMock,
+) -> None:
+    """Waiver signing event from an external participant should still be stored."""
+    mock_mongodb_handler_retrieve_one.return_value = None
+    await docusign_handler.process_webhook_event(SAMPLE_WEBHOOK_DATA)
+    mock_mongodb_handler_insert.assert_awaited_once_with(
+        Collection.USERS, {"_id": SAMPLE_UID, "status": Status.WAIVER_SIGNED}
+    )
+
+
+@patch("services.mongodb_handler.update_one", autospec=True)
+@patch("services.mongodb_handler.retrieve_one", autospec=True)
+async def test_user_record_updated_even_for_non_applicant(
+    mock_mongodb_handler_retrieve_one: AsyncMock,
+    mock_mongodb_handler_update_one: AsyncMock,
+) -> None:
+    """Test waiver status stored even for external participants with user record."""
+    mock_mongodb_handler_retrieve_one.return_value = {
+        "_id": SAMPLE_UID,
+        "role": Role.VOLUNTEER,
+    }
+    await docusign_handler.process_webhook_event(SAMPLE_WEBHOOK_DATA)
+    mock_mongodb_handler_update_one.assert_awaited_once_with(
+        Collection.USERS, {"_id": SAMPLE_UID}, {"status": Status.WAIVER_SIGNED}
+    )

--- a/apps/api/tests/test_user_waiver.py
+++ b/apps/api/tests/test_user_waiver.py
@@ -1,13 +1,18 @@
+from copy import deepcopy
 from datetime import datetime
+from unittest.mock import AsyncMock, Mock, patch
+from uuid import uuid4
 
 from fastapi import FastAPI
 from fastapi.testclient import TestClient
+from test_docusign_handler import SAMPLE_WEBHOOK_PAYLOAD
 from test_user_apply import SAMPLE_APPLICATION
 
 from auth.authorization import require_accepted_applicant
 from auth.user_identity import User
 from models.ApplicationData import Decision
 from routers import user
+from services import docusign_handler
 from utils.user_record import Applicant, Role, Status
 
 app = FastAPI()
@@ -65,3 +70,49 @@ def test_cannot_request_waiver_if_already_signed() -> None:
     assert res.status_code == 403
 
     app.dependency_overrides = {}
+
+
+def test_invalid_webhook_payload_is_rejected() -> None:
+    """Webhook endpoint rejects payloads that are not signed properly."""
+    res = client.post(
+        "/waiver",
+        json=SAMPLE_WEBHOOK_PAYLOAD,
+        headers={"x-docusign-signature-1": "bad-signature"},
+    )
+    assert res.status_code == 400
+
+
+@patch("services.docusign_handler.verify_webhook_signature", autospec=True)
+def test_unknown_powerform_is_rejected(mock_verify_webhook_signature: Mock) -> None:
+    """Webhook endpoint rejects unknown PowerForms."""
+    mock_verify_webhook_signature.return_value = True
+
+    invalid_webhook_payload = deepcopy(SAMPLE_WEBHOOK_PAYLOAD)
+    summary = invalid_webhook_payload["data"]["envelopeSummary"]  # type: ignore[index]
+    summary["powerForm"]["powerFormId"] = str(uuid4())
+    res = client.post(
+        "/waiver",
+        json=invalid_webhook_payload,
+        headers={"x-docusign-signature-1": "test-signature"},
+    )
+
+    mock_verify_webhook_signature.assert_called_once()
+    assert res.status_code == 400
+
+
+@patch("services.docusign_handler.process_webhook_event", autospec=True)
+def test_valid_webhook_payload_is_fine(mock_process_webhook_event: AsyncMock) -> None:
+    """Test valid content signature can be verified."""
+    docusign_handler.DOCUSIGN_HMAC_KEY = "sample-key"
+    res = client.post(
+        "/waiver",
+        json=SAMPLE_WEBHOOK_PAYLOAD,
+        headers={
+            "x-docusign-signature-1": "0SdXSeA1PbfLB1V6Wx8jZjwoCX6jL3f3EHDduciaJGI="
+        },
+    )
+
+    assert res.status_code == 200
+    mock_process_webhook_event.assert_awaited_once()
+
+    docusign_handler.DOCUSIGN_HMAC_KEY = ""


### PR DESCRIPTION
Resolves #218.

## Changes
- Create new POST route for `/user/waiver`
- Write handler functions to parse DocuSign Connect webhook event
	- Validate HMAC signature of event payload
	- Update user status accordingly
- Unit tests
- Update README.md

## Testing
We'll be assigning [the staging domain](https://staging.irvinehacks.com) for this deployment to allow testing with DocuSign's webhook.

1. Log into the staging deployment.
2. Notify me so I can grant you a status of `ACCEPTED`.
3. Navigate to https://staging.irvinehacks.com/api/user/waiver to access the waiver.
4. Complete the waiver.
5. Notify me so I can check whether your status has changed to `WAIVER_SIGNED`.

To test other scenarios, you can not ask me to grant you the `ACCEPTED` status and attempt to access `/user/waiver`. You should still be able to access the waiver, but now we are assuming you are an external participant. In this case, continue completing the waiver and notify me so I can check again whether your status has changed to `WAIVER_SIGNED`.

**Note:** After merging #244, users will be able to see whether they have signed the waiver in the user portal.