### PR TITLE
Create decision release endpoint for directors

### DIFF
--- a/apps/api/src/routers/admin.py
+++ b/apps/api/src/routers/admin.py
@@ -1,16 +1,19 @@
+import asyncio
 from datetime import datetime
 from logging import getLogger
 from typing import Any, Optional
 
 from fastapi import APIRouter, Body, Depends, HTTPException, status
-from pydantic import BaseModel, Field, TypeAdapter, ValidationError
+from pydantic import BaseModel, EmailStr, Field, TypeAdapter, ValidationError
 
 from auth.authorization import require_role
 from auth.user_identity import User, utc_now
 from models.ApplicationData import Decision, Review
 from services import mongodb_handler
 from services.mongodb_handler import BaseRecord, Collection
-from utils.user_record import Applicant, Role
+from utils import email_handler
+from utils.batched import batched
+from utils.user_record import Applicant, Role, Status
 
 log = getLogger(__name__)
 
@@ -104,6 +107,58 @@ async def submit_review(
     except RuntimeError:
         log.error("Could not submit review for %s", applicant)
         raise HTTPException(status.HTTP_500_INTERNAL_SERVER_ERROR)
+
+
+@router.post("/release", dependencies=[Depends(require_role([Role.DIRECTOR]))])
+async def release_decisions() -> None:
+    """Update applicant status based on decision and send decision emails."""
+    records = await mongodb_handler.retrieve(
+        Collection.USERS,
+        {"status": Status.REVIEWED},
+        ["_id", "application_data.reviews", "application_data.first_name"],
+    )
+
+    for record in records:
+        _include_review_decision(record)
+
+    for decision in (Decision.ACCEPTED, Decision.WAITLISTED, Decision.REJECTED):
+        group = [record for record in records if record["decision"] == decision]
+        if not group:
+            continue
+
+        await asyncio.gather(
+            *(_process_batch(batch, decision) for batch in batched(group, 100))
+        )
+
+
+async def _process_batch(batch: tuple[dict[str, Any], ...], decision: Decision) -> None:
+    uids: list[str] = [record["_id"] for record in batch]
+    log.info(f"Setting {','.join(uids)} as {decision}")
+    ok = await mongodb_handler.update(
+        Collection.USERS, {"_id": {"$in": uids}}, {"status": decision}
+    )
+    if not ok:
+        raise RuntimeError("gg wp")
+
+    # Send emails
+    log.info(f"Sending {decision} emails for {len(batch)} applicants")
+    await email_handler.send_decision_email(
+        map(_extract_personalizations, batch), decision
+    )
+
+
+def _extract_personalizations(decision_data: dict[str, Any]) -> tuple[str, EmailStr]:
+    name = decision_data["application_data"]["first_name"]
+    email = _recover_email_from_uid(decision_data["_id"])
+    return name, email
+
+
+def _recover_email_from_uid(uid: str) -> str:
+    """For NativeUsers, the email should still delivery properly."""
+    *reversed_domain, local = uid.split(".")
+    local = local.replace("..", ".")
+    domain = ".".join(reversed(reversed_domain))
+    return f"{local}@{domain}"
 
 
 def _include_review_decision(applicant_record: dict[str, Any]) -> None:

--- a/apps/api/src/utils/batched.py
+++ b/apps/api/src/utils/batched.py
@@ -1,0 +1,14 @@
+import itertools
+from typing import Iterable, Iterator, TypeVar
+
+T = TypeVar("T")
+
+
+def batched(iterable: Iterable[T], n: int) -> Iterator[tuple[T, ...]]:
+    """batched('ABCDEFG', 3) --> ABC DEF G"""
+    # from https://docs.python.org/3/library/itertools.html#itertools.batched
+    if n < 1:
+        raise ValueError("n must be at least one")
+    it = iter(iterable)
+    while batch := tuple(itertools.islice(it, n)):
+        yield batch

--- a/apps/api/src/utils/email_handler.py
+++ b/apps/api/src/utils/email_handler.py
@@ -1,4 +1,4 @@
-from typing import Protocol
+from typing import Iterable, Protocol
 
 from pydantic import EmailStr
 
@@ -52,7 +52,7 @@ async def send_guest_login_email(email: EmailStr, passphrase: str) -> None:
 
 
 async def send_decision_email(
-    applicant_batch: list[tuple[str, EmailStr]], decision: Decision
+    applicant_batch: Iterable[tuple[str, EmailStr]], decision: Decision
 ) -> None:
     """Send a specific decision email to a group of applicants."""
     personalizations = [

--- a/apps/api/tests/test_email_handler.py
+++ b/apps/api/tests/test_email_handler.py
@@ -1,36 +1,26 @@
-from unittest.mock import AsyncMock, call, patch
-
-from test_sendgrid_handler import SAMPLE_SENDER
+from unittest.mock import AsyncMock, patch
 
 from models.ApplicationData import Decision
 from services.sendgrid_handler import ApplicationUpdatePersonalization, Template
 from utils import email_handler
+from utils.email_handler import IH_SENDER
 
 
 @patch("services.sendgrid_handler.send_email")
 async def test_send_decision_email(mock_sendgrid_handler_send_email: AsyncMock) -> None:
-    applicants = {
-        ("test1", "test1@uci.edu"): Decision.ACCEPTED,
-        ("test2", "test2@uci.edu"): Decision.REJECTED,
-        ("test3", "test3@uci.edu"): Decision.WAITLISTED,
-    }
-
-    accepted = [
-        ApplicationUpdatePersonalization(first_name="test1", email="test1@uci.edu")
-    ]
-    rejected = [
-        ApplicationUpdatePersonalization(first_name="test2", email="test2@uci.edu")
-    ]
-    waitlisted = [
-        ApplicationUpdatePersonalization(first_name="test3", email="test3@uci.edu")
+    users = [
+        ("test1", "test1@uci.edu"),
+        ("test2", "test2@uci.edu"),
+        ("test3", "test3@uci.edu"),
     ]
 
-    await email_handler.send_decision_email(SAMPLE_SENDER, applicants)
+    expected_personalizations = [
+        ApplicationUpdatePersonalization(first_name=name, email=email)
+        for name, email in users
+    ]
 
-    mock_sendgrid_handler_send_email.assert_has_calls(
-        [
-            call(Template.ACCEPTED_EMAIL, SAMPLE_SENDER, accepted, True),
-            call(Template.REJECTED_EMAIL, SAMPLE_SENDER, rejected, True),
-            call(Template.WAITLISTED_EMAIL, SAMPLE_SENDER, waitlisted, True),
-        ]
+    await email_handler.send_decision_email(users, Decision.ACCEPTED)
+
+    mock_sendgrid_handler_send_email.assert_called_once_with(
+        Template.ACCEPTED_EMAIL, IH_SENDER, expected_personalizations, True
     )


### PR DESCRIPTION
Closes #242.

Worked with @taesungh to create a decision release endpoint accessible only by directors at `/api/admin/release`. It updates the statuses of applicants with their most recent review and sends out the respective decision emails via SendGrid.

We tested this locally on Docker MongoDB instances and it works as expected. The only concern is whether SendGrid will rate limit us for sending too many emails at once, although we did implement batching algorithms to work around this.