### PR TITLE
hotfix: _recover_email_from_uid bug

### DIFF
--- a/apps/api/src/routers/admin.py
+++ b/apps/api/src/routers/admin.py
@@ -155,8 +155,9 @@ def _extract_personalizations(decision_data: dict[str, Any]) -> tuple[str, Email
 
 def _recover_email_from_uid(uid: str) -> str:
     """For NativeUsers, the email should still delivery properly."""
+    uid = uid.replace("..", "\n")
     *reversed_domain, local = uid.split(".")
-    local = local.replace("..", ".")
+    local = local.replace("\n", ".")
     domain = ".".join(reversed(reversed_domain))
     return f"{local}@{domain}"
 


### PR DESCRIPTION
Resolves #263.

- Replace `..` with return char (`\n`) so splitting by `.` doesn't affect them
- Then replace the return char with `.` and continue as before