### PR TITLE
Update `/rsvp` endpoint to convert `ATTENDING` applicants to `VOID`

### DIFF
--- a/apps/api/src/routers/user.py
+++ b/apps/api/src/routers/user.py
@@ -228,6 +228,8 @@ async def rsvp(
         new_status = Status.CONFIRMED
     elif user_record["status"] == Status.CONFIRMED:
         new_status = Status.WAIVER_SIGNED
+    elif user_record["status"] == Status.ATTENDING:
+        new_status = Status.VOID
     else:
         raise HTTPException(
             status.HTTP_403_FORBIDDEN,

--- a/apps/api/src/utils/user_record.py
+++ b/apps/api/src/utils/user_record.py
@@ -22,6 +22,8 @@ class Status(str, Enum):
     REVIEWED = "REVIEWED"
     WAIVER_SIGNED = "WAIVER_SIGNED"
     CONFIRMED = "CONFIRMED"
+    ATTENDING = "ATTENDING"
+    VOID = "VOID"
 
 
 class UserRecord(BaseRecord):

--- a/apps/api/tests/test_user.py
+++ b/apps/api/tests/test_user.py
@@ -105,7 +105,7 @@ def test_user_with_status_attending_un_rsvp_changes_status_to_void(
     mock_mongodb_handler_retrieve_one: AsyncMock,
     mock_mongodb_handler_update_one: AsyncMock,
 ) -> None:
-    """Test user with WAIVER_SIGNED status has new status of VOID after RSVP."""
+    """Test user with ATTENDING status has new status of VOID after RSVP."""
     mock_mongodb_handler_retrieve_one.return_value = {"status": Status.ATTENDING}
 
     client = UserTestClient(GuestUser(email="tree@stanford.edu"), app)

--- a/apps/api/tests/test_user.py
+++ b/apps/api/tests/test_user.py
@@ -97,3 +97,22 @@ def test_user_with_status_confirmed_un_rsvp_changes_status_to_waiver_signed(
     )
 
     assert res.status_code == 303
+
+
+@patch("services.mongodb_handler.update_one", autospec=True)
+@patch("services.mongodb_handler.retrieve_one", autospec=True)
+def test_user_with_status_attending_un_rsvp_changes_status_to_void(
+    mock_mongodb_handler_retrieve_one: AsyncMock,
+    mock_mongodb_handler_update_one: AsyncMock,
+) -> None:
+    """Test user with WAIVER_SIGNED status has new status of VOID after RSVP."""
+    mock_mongodb_handler_retrieve_one.return_value = {"status": Status.ATTENDING}
+
+    client = UserTestClient(GuestUser(email="tree@stanford.edu"), app)
+    res = client.post("/rsvp", follow_redirects=False)
+
+    mock_mongodb_handler_update_one.assert_awaited_once_with(
+        Collection.USERS, {"_id": "edu.stanford.tree"}, {"status": Status.VOID}
+    )
+
+    assert res.status_code == 303


### PR DESCRIPTION
***NOTE***: Added `ATTENDING` and `VOID` statuses to `user_record.py` AHEAD of #275, but the only potential merge conflict would be a two line fix

---
Added unit test for converting `ATTENDING` status to `VOID`