### PR TITLE
Use Turborepo to cache `pip install` for API

### DIFF
--- a/apps/api/.gitignore
+++ b/apps/api/.gitignore
@@ -1,3 +1,4 @@
 __pycache__
 *.key
 .coverage
+lib

--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -7,6 +7,7 @@
 		"dev:default": "./run-docker.sh",
 		"test": "pytest",
 		"lint": "flake8 src tests && mypy src tests",
+		"build": "mkdir -p lib && pip install --target lib -r requirements.txt",
 		"format:write": "black src tests",
 		"format:check": "black --check src tests"
 	},

--- a/apps/api/turbo.json
+++ b/apps/api/turbo.json
@@ -1,0 +1,9 @@
+{
+	"extends": ["//"],
+	"pipeline": {
+		"build": {
+			"inputs": ["requirements.txt"],
+			"outputs": ["lib/**"]
+		}
+	}
+}

--- a/apps/site/copy-api.sh
+++ b/apps/site/copy-api.sh
@@ -1,4 +1,8 @@
 # Copy API files from apps/api
-cp -R ../api/{requirements.txt,configuration} .
+cp -R ../api/configuration .
 cp -R ../api/src/ src/api/
 cp ../api/index.py api/index.py
+
+# Copy Python libraries installed by during turbo build in apps/api
+# instead of having Vercel install using requirements.txt
+cp -R ../api/lib/* .

--- a/apps/site/vercel-lib.sh
+++ b/apps/site/vercel-lib.sh
@@ -21,12 +21,10 @@ lib_files=(
    libgpg-error.so.0.10.0
 )
 
+# These system libraries will be included in the Lambda deployment files
+# and accessible from Python through LD_LIBRARY_PATH
 mkdir lib
 for file in "${lib_files[@]}"
 do
    cp /usr/lib64/$file lib/
 done
-
-echo $PWD
-ls
-ls lib

--- a/apps/site/vercel.json
+++ b/apps/site/vercel.json
@@ -1,5 +1,5 @@
 {
-	"buildCommand": "cd ../.. && turbo run build --filter={apps/site} && cd apps/site && ./copy-api.sh && ./vercel-lib.sh",
+	"buildCommand": "./vercel-lib.sh && cd ../.. && turbo run build --filter={apps/site} --filter={apps/api} && cd apps/site && ./copy-api.sh",
 	"functions": {
 		"api/index.py": {
 			"memory": 512,


### PR DESCRIPTION
Resolves #284.

## Changes
- Instead of having Vercel install the Python dependencies for the API, run `pip install` with Turborepo so the library files can be cached
- Run system library installation before installing API dependencies

## Testing
Access `/api/saml/metadata` on the preview deployment to ensure FastAPI and xmlsec are still operational (system libraries are loaded properly).

## Impact
This will save around 30 seconds during each Vercel deployment, assuming `requirements.txt` has not changed.