### PR TITLE
feat: Displaying void message for applicants who failed to RSVP on time

### DIFF
--- a/apps/site/src/app/(main)/portal/@applicant/ApplicantPortal.tsx
+++ b/apps/site/src/app/(main)/portal/@applicant/ApplicantPortal.tsx
@@ -16,6 +16,7 @@ export const enum PortalStatus {
 	waived = "WAIVER_SIGNED",
 	confirmed = "CONFIRMED",
 	attending = "ATTENDING",
+	void = "VOID",
 }
 
 async function Portal() {

--- a/apps/site/src/app/(main)/portal/@applicant/Message.tsx
+++ b/apps/site/src/app/(main)/portal/@applicant/Message.tsx
@@ -42,6 +42,13 @@ function Message({ status }: MessageProps) {
 		[PortalStatus.waived]: <p>Thank you for signing the waiver!</p>,
 		[PortalStatus.confirmed]: <></>,
 		[PortalStatus.attending]: <></>,
+		[PortalStatus.void]: (
+			<p>
+				Unfortunately, you are not able to RSVP for IrvineHacks at this time and
+				will not be able to come to the event. However, we would love to see you
+				apply again next year!
+			</p>
+		),
 	};
 
 	return messages[status];

--- a/apps/site/src/app/(main)/portal/@applicant/VerticalTimeline.tsx
+++ b/apps/site/src/app/(main)/portal/@applicant/VerticalTimeline.tsx
@@ -125,7 +125,7 @@ function VerticalTimeline({ status }: VerticalTimelineProps) {
 					height={25}
 					className="m-6 mr-12"
 				/>
-				Sorry, you can not RSVP at this time.
+				Can not RSVP at this time.
 			</li>
 		) : null;
 

--- a/apps/site/src/app/(main)/portal/@applicant/VerticalTimeline.tsx
+++ b/apps/site/src/app/(main)/portal/@applicant/VerticalTimeline.tsx
@@ -31,7 +31,9 @@ function VerticalTimeline({ status }: VerticalTimelineProps) {
 	);
 
 	const verdict_component =
-		status === PortalStatus.accepted || signedWaiver ? (
+		status === PortalStatus.accepted ||
+		status === PortalStatus.void ||
+		signedWaiver ? (
 			<li className="flex flex-row items-center border-t">
 				<Image
 					src={CheckCircle}
@@ -113,6 +115,17 @@ function VerticalTimeline({ status }: VerticalTimelineProps) {
 					className="m-6 mr-12"
 				/>
 				Attendance confirmed
+			</li>
+		) : status === PortalStatus.void ? (
+			<li className="flex flex-row items-center border-t">
+				<Image
+					src={XCircle}
+					alt="checked-circle"
+					width={25}
+					height={25}
+					className="m-6 mr-12"
+				/>
+				Sorry, you can not RSVP at this time.
 			</li>
 		) : null;
 

--- a/apps/site/src/app/(main)/portal/@applicant/VerticalTimeline.tsx
+++ b/apps/site/src/app/(main)/portal/@applicant/VerticalTimeline.tsx
@@ -48,7 +48,7 @@ function VerticalTimeline({ status }: VerticalTimelineProps) {
 			<li className="flex flex-row items-center border-t">
 				<Image
 					src={XCircle}
-					alt="checked-circle"
+					alt="x-circle"
 					width={25}
 					height={25}
 					className="m-6 mr-12"
@@ -120,12 +120,12 @@ function VerticalTimeline({ status }: VerticalTimelineProps) {
 			<li className="flex flex-row items-center border-t">
 				<Image
 					src={XCircle}
-					alt="checked-circle"
+					alt="x-circle"
 					width={25}
 					height={25}
 					className="m-6 mr-12"
 				/>
-				Can not RSVP at this time.
+				No RSVP Indicated
 			</li>
 		) : null;
 


### PR DESCRIPTION
Resolves #281. Added display message and XCircle to applicants with the `VOID` status in the RSVP component as well as the two new statuses `ACCEPTED` and `VOID`. Verdict and submission components remain, but the waiver component is removed. Unsure if the language used for the display message would fit both scenarios mentioned well. 