### PR TITLE
Fix `NEXT_PUBLIC_` environment variables in cache

### DIFF
--- a/apps/site/src/lib/utils/api.ts
+++ b/apps/site/src/lib/utils/api.ts
@@ -2,7 +2,7 @@ import axios from "axios";
 import { cookies } from "next/headers";
 
 const LOCAL_API_URL = "http://localhost:8000";
-const SERVER_HOST = process.env.NEXT_PUBLIC_VERCEL_URL;
+const SERVER_HOST = process.env.VERCEL_URL;
 
 // The Vercel Serverless Function for the API lives outside the scope of Next.js
 // so the publicly deployed URL must be used instead of a rewrite

--- a/apps/site/turbo.json
+++ b/apps/site/turbo.json
@@ -2,6 +2,7 @@
 	"extends": ["//"],
 	"pipeline": {
 		"build": {
+			"env": ["NEXT_PUBLIC_SANITY_*"],
 			"inputs": [
 				"src/**",
 				"public/**",


### PR DESCRIPTION
Fixes #290.

## Changes
- Replace `NEXT_PUBLIC_VERCEL_URL` with `VERCEL_URL` to avoid inlining
- Add `NEXT_PUBLIC_SANITY_*` to Turborepo `pipeline.build.env` cache key

## Testing
Confirm deployment logs show that server-side API calls are going to the current deployment, even when the site build was from Full Turbo cache.