### PR TITLE
Create new volunteer and organizer roles limited to check-ins only

### DIFF
--- a/apps/api/src/utils/user_record.py
+++ b/apps/api/src/utils/user_record.py
@@ -13,7 +13,7 @@ class Role(str, Enum):
     HACKER = "hacker"
     MENTOR = "mentor"
     REVIEWER = "reviewer"
-    TECH_ORGANIZER = "tech_organizer"
+    ORGANIZER = "organizer"
     VOLUNTEER = "volunteer"
 
 

--- a/apps/site/src/app/(main)/portal/layout.tsx
+++ b/apps/site/src/app/(main)/portal/layout.tsx
@@ -1,6 +1,6 @@
 import { ReactNode } from "react";
 
-import { isAdminRole } from "@/lib/admin/adminRole";
+import { isAdminRole } from "@/lib/admin/authorization";
 import getUserIdentity from "@/lib/utils/getUserIdentity";
 
 import styles from "./Portal.module.scss";

--- a/apps/site/src/app/admin/applicants/Applicants.tsx
+++ b/apps/site/src/app/admin/applicants/Applicants.tsx
@@ -1,6 +1,8 @@
 "use client";
 
-import { useState } from "react";
+import { useRouter } from "next/navigation";
+
+import { useContext, useState } from "react";
 
 import Box from "@cloudscape-design/components/box";
 import Cards from "@cloudscape-design/components/cards";
@@ -13,7 +15,18 @@ import useApplicants, { ApplicantSummary } from "@/lib/admin/useApplicants";
 import ApplicantFilters, { Options } from "./components/ApplicantFilters";
 import ApplicantStatus from "./components/ApplicantStatus";
 
+import UserContext from "@/lib/admin/UserContext";
+import { isApplicationManager } from "@/lib/admin/authorization";
+
 function Applicants() {
+	const router = useRouter();
+
+	const { role } = useContext(UserContext);
+
+	if (!isApplicationManager(role)) {
+		router.push("/admin/dashboard");
+	}
+
 	const [selectedStatuses, setSelectedStatuses] = useState<Options>([]);
 	const [selectedDecisions, setSelectedDecisions] = useState<Options>([]);
 	const { applicantList, loading } = useApplicants();

--- a/apps/site/src/app/admin/layout/AdminLayout.tsx
+++ b/apps/site/src/app/admin/layout/AdminLayout.tsx
@@ -8,7 +8,7 @@ import AppLayout from "@cloudscape-design/components/app-layout";
 import axios from "axios";
 import { SWRConfig } from "swr";
 
-import { isAdminRole } from "@/lib/admin/adminRole";
+import { isAdminRole } from "@/lib/admin/authorization";
 import UserContext from "@/lib/admin/UserContext";
 import useUserIdentity from "@/lib/admin/useUserIdentity";
 

--- a/apps/site/src/app/admin/layout/AdminSidebar.tsx
+++ b/apps/site/src/app/admin/layout/AdminSidebar.tsx
@@ -1,20 +1,37 @@
 import { usePathname } from "next/navigation";
 
+import { useContext } from "react";
+
 import SideNavigation, {
 	SideNavigationProps,
 } from "@cloudscape-design/components/side-navigation";
 
 import { BASE_PATH, useFollowWithNextLink } from "./common";
+import { isApplicationManager } from "@/lib/admin/authorization";
+import UserContext from "@/lib/admin/UserContext";
 
 function AdminSidebar() {
 	const pathname = usePathname();
 	const followWithNextLink = useFollowWithNextLink();
 
+	const { role } = useContext(UserContext);
+
 	const navigationItems: SideNavigationProps.Item[] = [
-		{ type: "link", text: "Applicants", href: "/admin/applicants" },
+		{ type: "link", text: "Participants", href: "/admin/participants" },
 		{ type: "divider" },
 		{ type: "link", text: "Back to main site", href: "/" },
 	];
+
+	if (isApplicationManager(role)) {
+		navigationItems.unshift(
+			{
+				type: "link",
+				text: "Applicants",
+				href: "/admin/applicants",
+			},
+			{ type: "divider" },
+		);
+	}
 
 	return (
 		<SideNavigation

--- a/apps/site/src/app/admin/layout/Breadcrumbs.tsx
+++ b/apps/site/src/app/admin/layout/Breadcrumbs.tsx
@@ -12,6 +12,7 @@ interface PathTitles {
 
 const pathTitles: PathTitles = {
 	applicants: "Applicants",
+	participants: "Participants",
 };
 
 const DEFAULT_ITEMS = [{ text: "IrvineHacks 2024", href: BASE_PATH }];

--- a/apps/site/src/app/admin/participants/Participants.tsx
+++ b/apps/site/src/app/admin/participants/Participants.tsx
@@ -1,0 +1,5 @@
+function Participants() {
+	return <></>;
+}
+
+export default Participants;

--- a/apps/site/src/app/admin/participants/page.tsx
+++ b/apps/site/src/app/admin/participants/page.tsx
@@ -1,0 +1,1 @@
+export { default as default } from "./Participants";

--- a/apps/site/src/lib/admin/adminRole.ts
+++ b/apps/site/src/lib/admin/adminRole.ts
@@ -1,5 +1,0 @@
-const ADMIN_ROLES = ["director", "reviewer"];
-
-export function isAdminRole(role: string | null) {
-	return role !== null && ADMIN_ROLES.includes(role);
-}

--- a/apps/site/src/lib/admin/authorization.ts
+++ b/apps/site/src/lib/admin/authorization.ts
@@ -1,0 +1,13 @@
+const ADMIN_ROLES = ["director", "reviewer"];
+const ORGANIZER_ROLES = ["organizer", "volunteer"];
+
+export function isApplicationManager(role: string | null) {
+	return role !== null && ADMIN_ROLES.includes(role);
+}
+
+export function isAdminRole(role: string | null) {
+	return (
+		role !== null &&
+		(ADMIN_ROLES.includes(role) || ORGANIZER_ROLES.includes(role))
+	);
+}


### PR DESCRIPTION
- `tech_organizer` role replaced with `organizer`
- Update `isAdminRole` to allow organizer and volunteer
- Use separate `isApplicationManager` function for the previous admin roles (director and reviewer).
- Create an empty page called Participants for https://github.com/HackAtUCI/irvinehacks-site-2024/issues/269 and show this in the AdminSidebar
- Hide the Applicants path and restrict the related pages to roles which satisfy `isApplicationManager`
- Resolves #267 