### PR TITLE
feat: rsvp reminder route

### DIFF
--- a/apps/api/src/routers/admin.py
+++ b/apps/api/src/routers/admin.py
@@ -137,11 +137,13 @@ async def release_decisions() -> None:
 async def rsvp_reminder() -> None:
     """Send email to applicants who have a status of ACCEPTED or WAIVER_SIGNED
     reminding them to RSVP."""
+    # TODO: Consider using Pydantic model validation instead of type annotations
     not_yet_rsvpd: list[dict[str, Any]] = await mongodb_handler.retrieve(
         Collection.USERS,
         {"status": {"$in": [Decision.ACCEPTED, Status.WAIVER_SIGNED]}},
         ["_id", "application_data.first_name"],
     )
+    log.info(f"Sending RSVP reminder emails to {len(not_yet_rsvpd)} applicants")
     personalizations = [
         ApplicationUpdatePersonalization(
             email=_recover_email_from_uid(record["_id"]),

--- a/apps/api/src/routers/admin.py
+++ b/apps/api/src/routers/admin.py
@@ -9,10 +9,12 @@ from pydantic import BaseModel, EmailStr, Field, TypeAdapter, ValidationError
 from auth.authorization import require_role
 from auth.user_identity import User, utc_now
 from models.ApplicationData import Decision, Review
-from services import mongodb_handler
+from services import mongodb_handler, sendgrid_handler
 from services.mongodb_handler import BaseRecord, Collection
+from services.sendgrid_handler import ApplicationUpdatePersonalization, Template
 from utils import email_handler
 from utils.batched import batched
+from utils.email_handler import IH_SENDER, REPLY_TO_HACK_AT_UCI
 from utils.user_record import Applicant, Role, Status
 
 log = getLogger(__name__)
@@ -129,6 +131,29 @@ async def release_decisions() -> None:
         await asyncio.gather(
             *(_process_batch(batch, decision) for batch in batched(group, 100))
         )
+
+
+@router.post("/rsvp-reminder", dependencies=[Depends(require_role(Role.DIRECTOR))])
+async def rsvp_reminder():
+    not_yet_rsvpd = mongodb_handler.retrieve(
+        Collection,
+        {"status": {"$in": [Status.ACCEPTED, Status.WAIVER_SIGNED]}},
+        ["_id", "application_data.first_name"],
+    )
+    not_yet_rsvpd = [
+        ApplicationUpdatePersonalization(
+            email=_recover_email_from_uid(record["_id"]),
+            first_name=record["application_data.first_name"],
+        )
+        for record in not_yet_rsvpd
+    ]
+    await sendgrid_handler.send_email(
+        Template.RSVP_REMINDER,
+        IH_SENDER,
+        not_yet_rsvpd,
+        True,
+        reply_to=REPLY_TO_HACK_AT_UCI,
+    )
 
 
 async def _process_batch(batch: tuple[dict[str, Any], ...], decision: Decision) -> None:

--- a/apps/api/src/routers/admin.py
+++ b/apps/api/src/routers/admin.py
@@ -137,15 +137,15 @@ async def release_decisions() -> None:
 async def rsvp_reminder() -> None:
     """Send email to applicants who have a status of ACCEPTED or WAIVER_SIGNED
     reminding them to RSVP."""
-    not_yet_rsvpd = await mongodb_handler.retrieve(
+    not_yet_rsvpd: list[dict[str, Any]] = await mongodb_handler.retrieve(
         Collection.USERS,
         {"status": {"$in": [Decision.ACCEPTED, Status.WAIVER_SIGNED]}},
         ["_id", "application_data.first_name"],
     )
     personalizations = [
         ApplicationUpdatePersonalization(
-            email=_recover_email_from_uid(str(record["_id"])),
-            first_name=str(record["application_data.first_name"]),
+            email=_recover_email_from_uid(record["_id"]),
+            first_name=record["application_data"]["first_name"],
         )
         for record in not_yet_rsvpd
     ]

--- a/apps/api/src/services/sendgrid_handler.py
+++ b/apps/api/src/services/sendgrid_handler.py
@@ -21,6 +21,7 @@ class Template(str, Enum):
     WAITLISTED_EMAIL = "d-9178c043de134a71a4fdbe513d35f89f"
     REJECTED_EMAIL = "d-71ef30ac91a941e0893b7680928d80b7"
     WAITLIST_RELEASE_EMAIL = "d-19af50295ac14e82a7810791a175b8e9"
+    RSVP_REMINDER = "d-0c2642268c404c138359ac1b9d41e78c"
 
 
 class PersonalizationData(TypedDict):


### PR DESCRIPTION
Resolves #294 by creating a new admin route called `/admin/rsvp-reminder` restricted to directors only that checks for applicants whose status is either `ACCEPTED` or `WAIVER_SIGNED` and sends an RSVP reminder email to them.