### PR TITLE
Add `ATTENDING` and `VOID` statuses to Admin site

### DIFF
--- a/apps/site/src/app/admin/applicants/components/ApplicantFilters.tsx
+++ b/apps/site/src/app/admin/applicants/components/ApplicantFilters.tsx
@@ -33,6 +33,8 @@ const StatusIcons: Record<Status, IconProps.Name> = {
 	[Decision.waitlisted]: "status-negative",
 	[PostAcceptedStatus.signed]: "status-in-progress",
 	[PostAcceptedStatus.confirmed]: "status-positive",
+	[PostAcceptedStatus.attending]: "status-positive",
+	[PostAcceptedStatus.void]: "status-negative",
 };
 
 const statusOption = (status: Status): MultiselectProps.Option => ({

--- a/apps/site/src/app/admin/applicants/components/ApplicantStatus.tsx
+++ b/apps/site/src/app/admin/applicants/components/ApplicantStatus.tsx
@@ -13,6 +13,8 @@ export const StatusLabels = {
 	[Status.released]: "released",
 	[Status.signed]: "waiver signed",
 	[Status.confirmed]: "confirmed",
+	[Status.attending]: "attending",
+	[Status.void]: "void",
 };
 
 const StatusTypes: Record<Status, StatusIndicatorProps.Type> = {
@@ -23,7 +25,9 @@ const StatusTypes: Record<Status, StatusIndicatorProps.Type> = {
 	[Status.reviewed]: "in-progress",
 	[Status.released]: "success",
 	[Status.signed]: "in-progress",
-	[Status.confirmed]: "success",
+	[Status.confirmed]: "info",
+	[Status.attending]: "success",
+	[Status.void]: "stopped",
 };
 
 interface ApplicantStatusProps {

--- a/apps/site/src/lib/admin/useApplicant.ts
+++ b/apps/site/src/lib/admin/useApplicant.ts
@@ -43,6 +43,8 @@ export enum ReviewStatus {
 export enum PostAcceptedStatus {
 	signed = "WAIVER_SIGNED",
 	confirmed = "CONFIRMED",
+	attending = "ATTENDING",
+	void = "VOID",
 }
 
 export const Status = { ...ReviewStatus, ...Decision, ...PostAcceptedStatus };


### PR DESCRIPTION
Following from #276/#280 and ahead of #278, the Admin site needs to be aware of some new statuses.
- Add `ATTENDING` and `VOID` to `PostAcceptedStatus`
- Update `StatusLabels`, `StatusTypes`, and `StatusIcons`