### PR TITLE
Add Applicant Status Summary to Admin Dashboard

### DIFF
--- a/apps/api/src/admin/summary_handler.py
+++ b/apps/api/src/admin/summary_handler.py
@@ -1,0 +1,26 @@
+from collections import Counter
+from typing import Union
+
+from pydantic import BaseModel, TypeAdapter
+
+from models.ApplicationData import Decision
+from services import mongodb_handler
+from services.mongodb_handler import Collection
+from utils.user_record import Role, Status
+
+
+class ApplicantSummaryRecord(BaseModel):
+    status: Union[Status, Decision]
+
+
+async def applicant_summary() -> Counter[Union[Status, Decision]]:
+    """Get summary of applicants by status."""
+    records = await mongodb_handler.retrieve(
+        Collection.USERS,
+        {"role": Role.APPLICANT},
+        ["status"],
+    )
+    applicants = TypeAdapter(list[ApplicantSummaryRecord]).validate_python(records)
+
+    by_status = Counter(applicant.status for applicant in applicants)
+    return by_status

--- a/apps/api/src/admin/summary_handler.py
+++ b/apps/api/src/admin/summary_handler.py
@@ -1,19 +1,17 @@
 from collections import Counter
-from typing import Union
 
 from pydantic import BaseModel, TypeAdapter
 
-from models.ApplicationData import Decision
 from services import mongodb_handler
 from services.mongodb_handler import Collection
-from utils.user_record import Role, Status
+from utils.user_record import ApplicantStatus, Role
 
 
 class ApplicantSummaryRecord(BaseModel):
-    status: Union[Status, Decision]
+    status: ApplicantStatus
 
 
-async def applicant_summary() -> Counter[Union[Status, Decision]]:
+async def applicant_summary() -> Counter[ApplicantStatus]:
     """Get summary of applicants by status."""
     records = await mongodb_handler.retrieve(
         Collection.USERS,
@@ -22,5 +20,4 @@ async def applicant_summary() -> Counter[Union[Status, Decision]]:
     )
     applicants = TypeAdapter(list[ApplicantSummaryRecord]).validate_python(records)
 
-    by_status = Counter(applicant.status for applicant in applicants)
-    return by_status
+    return Counter(applicant.status for applicant in applicants)

--- a/apps/api/src/routers/admin.py
+++ b/apps/api/src/routers/admin.py
@@ -1,11 +1,12 @@
 import asyncio
 from datetime import datetime
 from logging import getLogger
-from typing import Any, Optional
+from typing import Any, Optional, Union
 
 from fastapi import APIRouter, Body, Depends, HTTPException, status
 from pydantic import BaseModel, EmailStr, Field, TypeAdapter, ValidationError
 
+from admin import summary_handler
 from auth.authorization import require_role
 from auth.user_identity import User, utc_now
 from models.ApplicationData import Decision, Review
@@ -84,6 +85,15 @@ async def applicant(
         return Applicant.model_validate(record)
     except ValidationError:
         raise RuntimeError("Could not parse applicant data.")
+
+
+@router.get(
+    "/summary/applicants",
+    dependencies=[Depends(require_role(ADMIN_ROLES))],
+)
+async def applicant_summary() -> dict[Union[Status, Decision], int]:
+    """Provide summary of statuses of applicants."""
+    return await summary_handler.applicant_summary()
 
 
 @router.post("/review")

--- a/apps/api/src/routers/admin.py
+++ b/apps/api/src/routers/admin.py
@@ -1,7 +1,7 @@
 import asyncio
 from datetime import datetime
 from logging import getLogger
-from typing import Any, Optional, Union
+from typing import Any, Optional
 
 from fastapi import APIRouter, Body, Depends, HTTPException, status
 from pydantic import BaseModel, EmailStr, Field, TypeAdapter, ValidationError
@@ -16,7 +16,7 @@ from services.sendgrid_handler import ApplicationUpdatePersonalization, Template
 from utils import email_handler
 from utils.batched import batched
 from utils.email_handler import IH_SENDER, REPLY_TO_HACK_AT_UCI
-from utils.user_record import Applicant, Role, Status
+from utils.user_record import Applicant, ApplicantStatus, Role, Status
 
 log = getLogger(__name__)
 
@@ -91,7 +91,7 @@ async def applicant(
     "/summary/applicants",
     dependencies=[Depends(require_role(ADMIN_ROLES))],
 )
-async def applicant_summary() -> dict[Union[Status, Decision], int]:
+async def applicant_summary() -> dict[ApplicantStatus, int]:
     """Provide summary of statuses of applicants."""
     return await summary_handler.applicant_summary()
 

--- a/apps/api/src/utils/user_record.py
+++ b/apps/api/src/utils/user_record.py
@@ -2,6 +2,7 @@ from enum import Enum
 from typing import Literal, Union
 
 from pydantic import Field
+from typing_extensions import TypeAlias
 
 from models.ApplicationData import Decision, ProcessedApplicationData
 from services.mongodb_handler import BaseRecord
@@ -31,7 +32,10 @@ class UserRecord(BaseRecord):
     role: Role
 
 
+ApplicantStatus: TypeAlias = Union[Status, Decision]
+
+
 class Applicant(UserRecord):
     role: Literal[Role.APPLICANT] = Role.APPLICANT
-    status: Union[Status, Decision]
+    status: ApplicantStatus
     application_data: ProcessedApplicationData

--- a/apps/api/tests/test_summary_handler.py
+++ b/apps/api/tests/test_summary_handler.py
@@ -1,0 +1,23 @@
+from unittest.mock import AsyncMock, patch
+
+from admin.summary_handler import applicant_summary
+
+
+@patch("services.mongodb_handler.retrieve", autospec=True)
+async def test_applicant_summary(mock_mongodb_handler_retrieve: AsyncMock) -> None:
+    """Test applicant summary counts by status."""
+    mock_mongodb_handler_retrieve.return_value = (
+        [{"status": "ACCEPTED"}, {"status": "REJECTED"}] * 20
+        + [{"status": "CONFIRMED"}] * 24
+        + [{"status": "WAITLISTED"}, {"status": "WAIVER_SIGNED"}] * 3
+    )
+
+    summary = await applicant_summary()
+    mock_mongodb_handler_retrieve.assert_awaited_once()
+    assert dict(summary) == {
+        "REJECTED": 20,
+        "WAITLISTED": 3,
+        "ACCEPTED": 20,
+        "WAIVER_SIGNED": 3,
+        "CONFIRMED": 24,
+    }

--- a/apps/site/src/app/admin/dashboard/AdminDashboard.tsx
+++ b/apps/site/src/app/admin/dashboard/AdminDashboard.tsx
@@ -2,11 +2,17 @@
 
 import Container from "@cloudscape-design/components/container";
 import ContentLayout from "@cloudscape-design/components/content-layout";
+import SpaceBetween from "@cloudscape-design/components/space-between";
+
+import ApplicantSummary from "./components/ApplicantSummary";
 
 function AdminDashboard() {
 	return (
 		<ContentLayout>
-			<Container>Admin Dashboard</Container>
+			<SpaceBetween size="l">
+				<Container>Admin Dashboard</Container>
+				<ApplicantSummary />
+			</SpaceBetween>
 		</ContentLayout>
 	);
 }

--- a/apps/site/src/app/admin/dashboard/AdminDashboard.tsx
+++ b/apps/site/src/app/admin/dashboard/AdminDashboard.tsx
@@ -1,17 +1,24 @@
 "use client";
 
+import { useContext } from "react";
+
 import Container from "@cloudscape-design/components/container";
 import ContentLayout from "@cloudscape-design/components/content-layout";
 import SpaceBetween from "@cloudscape-design/components/space-between";
 
+import { isApplicationManager } from "@/lib/admin/authorization";
+import UserContext from "@/lib/admin/UserContext";
+
 import ApplicantSummary from "./components/ApplicantSummary";
 
 function AdminDashboard() {
+	const { role } = useContext(UserContext);
+
 	return (
 		<ContentLayout>
 			<SpaceBetween size="l">
 				<Container>Admin Dashboard</Container>
-				<ApplicantSummary />
+				{isApplicationManager(role) && <ApplicantSummary />}
 			</SpaceBetween>
 		</ContentLayout>
 	);

--- a/apps/site/src/app/admin/dashboard/components/ApplicantSummary.tsx
+++ b/apps/site/src/app/admin/dashboard/components/ApplicantSummary.tsx
@@ -1,0 +1,57 @@
+import Box from "@cloudscape-design/components/box";
+import Container from "@cloudscape-design/components/container";
+import PieChart from "@cloudscape-design/components/pie-chart";
+
+import { Status } from "@/lib/admin/useApplicant";
+
+import useApplicantSummary from "./useApplicantSummary";
+
+function ApplicantSummary() {
+	const { summary, loading, error } = useApplicantSummary();
+	const totalApplicants = Object.values(summary).reduce((s, v) => s + v, 0);
+
+	const orderedData = [
+		Status.rejected,
+		Status.waitlisted,
+		Status.accepted,
+		Status.signed,
+		Status.confirmed,
+		Status.attending,
+		Status.void,
+	].map((status) => ({
+		title: status,
+		value: summary[status] ?? 0,
+	}));
+
+	return (
+		<Container header={<Box variant="h2">Applicant Summary</Box>}>
+			<PieChart
+				data={orderedData}
+				statusType={(loading && "loading") || (error && "error")}
+				loadingText="Loading chart"
+				hideFilter={true}
+				segmentDescription={(datum, sum) =>
+					`${datum.value} applicants (${percentage(datum.value / sum)}%)`
+				}
+				ariaDescription="Donut chart showing summary of applicant statuses."
+				ariaLabel="Donut chart"
+				innerMetricDescription="total applicants"
+				innerMetricValue={`${totalApplicants}`}
+				size="large"
+				variant="donut"
+				empty={
+					<Box textAlign="center" color="inherit">
+						<b>No data available</b>
+						<Box variant="p" color="inherit">
+							There is no data available
+						</Box>
+					</Box>
+				}
+			/>
+		</Container>
+	);
+}
+
+const percentage = (value: number): string => (value * 100).toFixed(0);
+
+export default ApplicantSummary;

--- a/apps/site/src/app/admin/dashboard/components/useApplicantSummary.ts
+++ b/apps/site/src/app/admin/dashboard/components/useApplicantSummary.ts
@@ -1,0 +1,26 @@
+import axios from "axios";
+import useSWR from "swr";
+
+import { Status } from "@/lib/admin/useApplicant";
+
+type ApplicantSummary = Partial<Record<Status, number>>;
+
+const fetcher = async (url: string) => {
+	const res = await axios.get<ApplicantSummary>(url);
+	return res.data;
+};
+
+function useApplicantSummary() {
+	const { data, error, isLoading } = useSWR<ApplicantSummary>(
+		"/api/admin/summary/applicants",
+		fetcher,
+	);
+
+	return {
+		summary: data ?? ({} as ApplicantSummary),
+		loading: isLoading,
+		error,
+	};
+}
+
+export default useApplicantSummary;

--- a/apps/site/src/app/admin/layout/AdminSidebar.tsx
+++ b/apps/site/src/app/admin/layout/AdminSidebar.tsx
@@ -6,9 +6,10 @@ import SideNavigation, {
 	SideNavigationProps,
 } from "@cloudscape-design/components/side-navigation";
 
-import { BASE_PATH, useFollowWithNextLink } from "./common";
 import { isApplicationManager } from "@/lib/admin/authorization";
 import UserContext from "@/lib/admin/UserContext";
+
+import { BASE_PATH, useFollowWithNextLink } from "./common";
 
 function AdminSidebar() {
 	const pathname = usePathname();
@@ -17,20 +18,18 @@ function AdminSidebar() {
 	const { role } = useContext(UserContext);
 
 	const navigationItems: SideNavigationProps.Item[] = [
+		{ type: "link", text: "Dashboard", href: "/admin/dashboard" },
 		{ type: "link", text: "Participants", href: "/admin/participants" },
 		{ type: "divider" },
 		{ type: "link", text: "Back to main site", href: "/" },
 	];
 
 	if (isApplicationManager(role)) {
-		navigationItems.unshift(
-			{
-				type: "link",
-				text: "Applicants",
-				href: "/admin/applicants",
-			},
-			{ type: "divider" },
-		);
+		navigationItems.splice(1, 0, {
+			type: "link",
+			text: "Applicants",
+			href: "/admin/applicants",
+		});
 	}
 
 	return (


### PR DESCRIPTION
To help the applications committee decide how many people to accept from the waitlist, we can provide a chart summarizing the number of applicants in each status.

<img src="https://github.com/HackAtUCI/irvinehacks-site-2024/assets/44419552/f097ae6f-82ad-4ccf-b77b-d827ad4c2361" width="835" alt="Donut chart showing the breakdown of applicants by status" />

Resolves #278.

## Changes
- Add Admin endpoint for applicant status summary
  - Create new `summary_handler` file for various stats
- Add applicant summary chart to Admin Dashboard
  - Show [donut chart](https://cloudscape.design/components/pie-chart/?tabId=playground&example=donut-chart) of applicants by status on Admin Dashboard
  - Display count and percentages for each status
- Show **Dashboard** link in `AdminSidebar`
  - Remove divider for Applicants link and splice in when accessible