### PR TITLE
Waitlist release route

### DIFF
--- a/apps/api/src/services/sendgrid_handler.py
+++ b/apps/api/src/services/sendgrid_handler.py
@@ -8,6 +8,7 @@ from typing import Iterable, Literal, Tuple, TypedDict, Union, overload
 import aiosendgrid
 from httpx import HTTPStatusError
 from sendgrid.helpers.mail import Email, Mail, Personalization
+from typing_extensions import TypeAlias
 
 log = getLogger(__name__)
 
@@ -20,8 +21,8 @@ class Template(str, Enum):
     ACCEPTED_EMAIL = "d-062e7106a0d64d49ad9f03325bbc7286"
     WAITLISTED_EMAIL = "d-9178c043de134a71a4fdbe513d35f89f"
     REJECTED_EMAIL = "d-71ef30ac91a941e0893b7680928d80b7"
-    WAITLIST_RELEASE_EMAIL = "d-19af50295ac14e82a7810791a175b8e9"
     RSVP_REMINDER = "d-0c2642268c404c138359ac1b9d41e78c"
+    WAITLIST_RELEASE_EMAIL = "d-19af50295ac14e82a7810791a175b8e9"
 
 
 class PersonalizationData(TypedDict):
@@ -39,6 +40,15 @@ class GuestTokenPersonalization(PersonalizationData):
 
 class ApplicationUpdatePersonalization(PersonalizationData):
     first_name: str
+
+
+ApplicationUpdateTemplates: TypeAlias = Literal[
+    Template.ACCEPTED_EMAIL,
+    Template.WAITLISTED_EMAIL,
+    Template.REJECTED_EMAIL,
+    Template.RSVP_REMINDER,
+    Template.WAITLIST_RELEASE_EMAIL,
+]
 
 
 @overload
@@ -76,10 +86,21 @@ async def send_email(
 
 @overload
 async def send_email(
-    template_id: Template,
+    template_id: ApplicationUpdateTemplates,
     sender_email: Tuple[str, str],
     receiver_data: Iterable[ApplicationUpdatePersonalization],
     send_to_multiple: Literal[True],
+    reply_to: Union[Tuple[str, str], None] = None,
+) -> None:
+    ...
+
+
+@overload
+async def send_email(
+    template_id: ApplicationUpdateTemplates,
+    sender_email: Tuple[str, str],
+    receiver_data: ApplicationUpdatePersonalization,
+    send_to_multiple: Literal[False],
     reply_to: Union[Tuple[str, str], None] = None,
 ) -> None:
     ...

--- a/apps/api/src/utils/email_handler.py
+++ b/apps/api/src/utils/email_handler.py
@@ -4,12 +4,16 @@ from pydantic import EmailStr
 
 from models.ApplicationData import Decision
 from services import sendgrid_handler
-from services.sendgrid_handler import ApplicationUpdatePersonalization, Template
+from services.sendgrid_handler import (
+    ApplicationUpdatePersonalization,
+    ApplicationUpdateTemplates,
+    Template,
+)
 
 IH_SENDER = ("apply@irvinehacks.com", "IrvineHacks 2024 Applications")
 REPLY_TO_HACK_AT_UCI = ("hack@uci.edu", "Hack at UCI")
 
-DECISION_TEMPLATES = {
+DECISION_TEMPLATES: dict[Decision, ApplicationUpdateTemplates] = {
     Decision.ACCEPTED: Template.ACCEPTED_EMAIL,
     Decision.REJECTED: Template.REJECTED_EMAIL,
     Decision.WAITLISTED: Template.WAITLISTED_EMAIL,
@@ -62,3 +66,18 @@ async def send_decision_email(
 
     template = DECISION_TEMPLATES[decision]
     await sendgrid_handler.send_email(template, IH_SENDER, personalizations, True)
+
+
+async def send_waitlist_release_email(first_name: str, email: EmailStr) -> None:
+    """Send the waitlist release email to an applicant."""
+    personalization = ApplicationUpdatePersonalization(
+        email=email, first_name=first_name
+    )
+
+    await sendgrid_handler.send_email(
+        Template.WAITLIST_RELEASE_EMAIL,
+        IH_SENDER,
+        personalization,
+        send_to_multiple=False,
+        reply_to=REPLY_TO_HACK_AT_UCI,
+    )


### PR DESCRIPTION
Resolves #307.

## Changes
- Set up new route at `/admin/waitlist-release`
- Adjust `sendgrid_handler.send_email` overloads
- Create new send waitlist email helper function
- Unit tests

**Note:** While this is only accessible by directors at the moment, we will add a dedicated `CHECKIN_LEAD` role in #315.