### PR TITLE
Update access to participant check-in system

### DIFF
--- a/apps/api/src/routers/admin.py
+++ b/apps/api/src/routers/admin.py
@@ -23,7 +23,7 @@ log = getLogger(__name__)
 router = APIRouter()
 
 ADMIN_ROLES = (Role.DIRECTOR, Role.REVIEWER, Role.CHECKIN_LEAD)
-ORGANIZER_ROLES = (Role.ORGANIZER, Role.VOLUNTEER)
+ORGANIZER_ROLES = (Role.ORGANIZER,)
 
 require_checkin_associate = require_role(ADMIN_ROLES + ORGANIZER_ROLES)
 

--- a/apps/api/src/routers/admin.py
+++ b/apps/api/src/routers/admin.py
@@ -1,7 +1,7 @@
 import asyncio
 from datetime import datetime
 from logging import getLogger
-from typing import Any, Optional, Sequence
+from typing import Annotated, Any, Optional, Sequence
 
 from fastapi import APIRouter, Body, Depends, HTTPException, status
 from pydantic import BaseModel, EmailStr, Field, TypeAdapter, ValidationError
@@ -23,6 +23,9 @@ log = getLogger(__name__)
 router = APIRouter()
 
 ADMIN_ROLES = (Role.DIRECTOR, Role.REVIEWER, Role.CHECKIN_LEAD)
+ORGANIZER_ROLES = (Role.ORGANIZER, Role.VOLUNTEER)
+
+require_checkin_associate = require_role(ADMIN_ROLES + ORGANIZER_ROLES)
 
 
 class ApplicationDataSummary(BaseModel):
@@ -239,12 +242,7 @@ async def waitlist_release(uid: str) -> None:
     log.info(f"Accepted {uid} off the waitlist and sent email.")
 
 
-@router.get(
-    "/attending",
-    dependencies=[
-        Depends(require_role([Role.DIRECTOR, Role.ORGANIZER, Role.VOLUNTEER]))
-    ],
-)
+@router.get("/attending", dependencies=[Depends(require_checkin_associate)])
 async def attending() -> list[dict[str, object]]:
     """Get list of attending participants."""
     # TODO: non-hackers
@@ -253,10 +251,7 @@ async def attending() -> list[dict[str, object]]:
 
 @router.post("/checkin/{uid}")
 async def checkin(
-    uid: str,
-    associate: User = Depends(
-        require_role([Role.DIRECTOR, Role.ORGANIZER, Role.VOLUNTEER])
-    ),
+    uid: str, associate: Annotated[User, Depends(require_checkin_associate)]
 ) -> None:
     """Check in participant at IrvineHacks."""
     try:

--- a/apps/site/src/lib/admin/authorization.ts
+++ b/apps/site/src/lib/admin/authorization.ts
@@ -1,5 +1,5 @@
 const ADMIN_ROLES = ["director", "reviewer", "checkin_lead"];
-const ORGANIZER_ROLES = ["organizer", "volunteer"];
+const ORGANIZER_ROLES = ["organizer"];
 
 export function isApplicationManager(role: string | null) {
 	return role !== null && ADMIN_ROLES.includes(role);


### PR DESCRIPTION
As part of #266 and following from #268/#321, #315/#323, and #267, tests pending in #324.
- Include check-in leads in roles allowed to view/check in participants
- Remove access to check-in system for volunteers
  - Volunteers will no longer be assisting with primary event check-in