### PR TITLE
API check-in system modifications

### DIFF
--- a/apps/api/src/admin/participant_manager.py
+++ b/apps/api/src/admin/participant_manager.py
@@ -1,5 +1,5 @@
 from logging import getLogger
-from typing import Any, Optional
+from typing import Any, Optional, Union
 
 from auth.user_identity import User, utc_now
 from models.ApplicationData import Decision
@@ -15,7 +15,7 @@ class Participant(UserRecord):
 
     first_name: str
     last_name: str
-    status: Status
+    status: Union[Status, Decision]
 
 
 async def get_hackers() -> list[Participant]:
@@ -30,6 +30,7 @@ async def get_hackers() -> list[Participant]:
                     Status.ATTENDING,
                     Status.WAIVER_SIGNED,
                     Status.CONFIRMED,
+                    Decision.ACCEPTED,
                     Decision.WAITLISTED,
                 ]
             },

--- a/apps/api/src/admin/participant_manager.py
+++ b/apps/api/src/admin/participant_manager.py
@@ -18,8 +18,8 @@ class Participant(UserRecord):
     status: Status
 
 
-async def get_attending_applicants() -> list[Participant]:
-    """Fetch all applicants who have a status of ATTENIDNG, WAIVER_SIGNED, CONFIRMED,
+async def get_hackers() -> list[Participant]:
+    """Fetch all applicants who have a status of ATTENDING, WAIVER_SIGNED, CONFIRMED,
     or WAITLISTED."""
     records: list[dict[str, Any]] = await mongodb_handler.retrieve(
         Collection.USERS,


### PR DESCRIPTION
Completes the API side of the tasks mentioned in #340. Waiting on the modal in the admin frontend to be completed first by #341.

## Changes
- Include hackers with status (`ACCEPTED`, `WAITLISTED`, `WAIVER_SIGNED`, `CONFIRMED`) in `/admin/participants` endpoint
- Allow check-in leads, along with directors to use the `/admin/checkin` endpoint on `CONFIRMED` participants