### PR TITLE
Make Schedule visible on Navbar and fix countdown and scheule page

### DIFF
--- a/apps/site/src/app/(main)/schedule/components/ShiftingCountdown/ShiftingCountdown.tsx
+++ b/apps/site/src/app/(main)/schedule/components/ShiftingCountdown/ShiftingCountdown.tsx
@@ -9,12 +9,12 @@ import { Fireworks } from "@fireworks-js/react";
 import styles from "./ShiftingCountdown.module.scss";
 
 // NOTE: Change this date to whatever date you want to countdown to :)
-const HACKING_STARTS = "2024-01-26T18:00:00.000";
-const HACKING_ENDS = "2024-01-28T24:00:00.000";
+const HACKING_STARTS = Date.UTC(2024, 0, 27, 2, 0, 0); // 1/26 at 6pm PST
+const HACKING_ENDS = Date.UTC(2024, 0, 28, 20, 0, 0); // 1/28 at 12pm PST
 
 // Testing:
-// const HACKING_STARTS = "2023-12-09T21:42:00.000";
-// const HACKING_ENDS = "2023-12-09T21:44:00.000";
+// const HACKING_STARTS = "2024-01-25T01:18:00.000";
+// const HACKING_ENDS = "2024-01-25T01:19:00.000";
 
 const SECOND = 1000;
 const MINUTE = SECOND * 60;
@@ -56,8 +56,14 @@ const ShiftingCountdown = () => {
 		const minutes = Math.floor((distance % HOUR) / MINUTE);
 		const seconds = Math.floor((distance % MINUTE) / SECOND);
 
-		if (days === 0 && hours === 0 && minutes === 0 && seconds === 0) {
-			// triggers when HACKING_STARTS timer ends and HACKING_ENDS timer ends
+		if (
+			days === 0 &&
+			hours === 0 &&
+			minutes === 0 &&
+			seconds === 0 &&
+			now >= new Date(HACKING_ENDS)
+		) {
+			// triggers when HACKING_ENDS timer ends
 			setCountdown((prev) => {
 				return { ...prev, showFireworks: true };
 			});
@@ -104,7 +110,7 @@ const ShiftingCountdown = () => {
 				)}
 			</div>
 			{countdown.showFireworks && (
-				<div className="flex justify-center z-20">
+				<div className="flex justify-center">
 					<Fireworks
 						className="w-full h-full absolute"
 						options={{

--- a/apps/site/src/app/(main)/schedule/components/getSchedule.ts
+++ b/apps/site/src/app/(main)/schedule/components/getSchedule.ts
@@ -48,7 +48,9 @@ const Events = z.array(
 
 export const getSchedule = cache(async () => {
 	const events = Events.parse(
-		await client.fetch("*[_type == 'event'] | order(startTime asc)"),
+		await client.fetch(
+			"*[_type == 'event'] | order(startTime asc, endTime asc)",
+		),
 	);
 	const eventsByDay = new Map<string, z.infer<typeof Events>>();
 

--- a/apps/site/src/app/(main)/schedule/sections/SchedulePage.tsx
+++ b/apps/site/src/app/(main)/schedule/sections/SchedulePage.tsx
@@ -117,19 +117,11 @@ export default function SchedulePage({ schedule }: ScheduleProps) {
 					className="flex flex-col justify-center items-center w-full"
 				>
 					<Tabs.Content
-						value={weekdayFormat.format(
-							convertToPST(day[0].startTime),
-						)}
+						value={weekdayFormat.format(convertToPST(day[0].startTime))}
 						className="w-full"
 					>
 						{day.map((event) => {
-							return (
-								<EventCard
-									key={event.title}
-									now={now}
-									{...event}
-								/>
-							);
+							return <EventCard key={event.title} now={now} {...event} />;
 						})}
 					</Tabs.Content>
 				</div>

--- a/apps/site/src/lib/components/Navbar/Navbar.tsx
+++ b/apps/site/src/lib/components/Navbar/Navbar.tsx
@@ -72,9 +72,9 @@ function Navbar({ identity }: NavbarProps) {
 				>
 					{/* <NavLinkItem href="/">Home</NavLinkItem>
 					<NavLinkItem href="/">Sponsor</NavLinkItem>
-					<NavLinkItem href="/">Schedule</NavLinkItem>
 					<NavLinkItem href="/">Resources</NavLinkItem>
 					<NavLinkItem href="/">Stage</NavLinkItem> */}
+					<NavLinkItem href="/schedule">Schedule</NavLinkItem>
 					{!status && !deadlinePassed && (
 						<NavLinkItem href="/apply">Apply</NavLinkItem>
 					)}


### PR DESCRIPTION
- Fixes countdown so that fireworks only show up after IH ends (1/28 at 12pm PST).
- Fixes ordering of the events so now events are sorted by start date then end date.
- Adds Schedule to the Navbar
- There is still a lingering issue where the fireworks will block interaction with the Schedule Tabs, but this can be taken care of in another PR