### PR TITLE
update/removed review access after release

### DIFF
--- a/apps/api/src/routers/admin.py
+++ b/apps/api/src/routers/admin.py
@@ -100,29 +100,29 @@ async def applicant_summary() -> dict[ApplicantStatus, int]:
     return await summary_handler.applicant_summary()
 
 
-@router.post("/review")
-async def submit_review(
-    applicant: str = Body(),
-    decision: Decision = Body(),
-    reviewer: User = Depends(require_role([Role.REVIEWER])),
-) -> None:
-    """Submit a review decision from the reviewer for the given applicant."""
-    log.info("%s reviewed applicant %s", reviewer, applicant)
+# @router.post("/review")
+# async def submit_review(
+#     applicant: str = Body(),
+#     decision: Decision = Body(),
+#     reviewer: User = Depends(require_role([Role.REVIEWER])),
+# ) -> None:
+#     """Submit a review decision from the reviewer for the given applicant."""
+#     log.info("%s reviewed applicant %s", reviewer, applicant)
 
-    review: Review = (utc_now(), reviewer.uid, decision)
+#     review: Review = (utc_now(), reviewer.uid, decision)
 
-    try:
-        await mongodb_handler.raw_update_one(
-            Collection.USERS,
-            {"_id": applicant},
-            {
-                "$push": {"application_data.reviews": review},
-                "$set": {"status": "REVIEWED"},
-            },
-        )
-    except RuntimeError:
-        log.error("Could not submit review for %s", applicant)
-        raise HTTPException(status.HTTP_500_INTERNAL_SERVER_ERROR)
+#     try:
+#         await mongodb_handler.raw_update_one(
+#             Collection.USERS,
+#             {"_id": applicant},
+#             {
+#                 "$push": {"application_data.reviews": review},
+#                 "$set": {"status": "REVIEWED"},
+#             },
+#         )
+#     except RuntimeError:
+#         log.error("Could not submit review for %s", applicant)
+#         raise HTTPException(status.HTTP_500_INTERNAL_SERVER_ERROR)
 
 
 @router.post("/release", dependencies=[Depends(require_role([Role.DIRECTOR]))])

--- a/apps/api/tests/test_admin.py
+++ b/apps/api/tests/test_admin.py
@@ -141,33 +141,33 @@ def test_no_decision_from_no_reviews() -> None:
     assert record["decision"] is None
 
 
-@patch("services.mongodb_handler.raw_update_one", autospec=True)
-@patch("services.mongodb_handler.retrieve_one", autospec=True)
-def test_can_submit_review(
-    mock_mongodb_handler_retrieve_one: AsyncMock,
-    mock_mongodb_handler_raw_update_one: AsyncMock,
-) -> None:
-    """Test that a user can properly submit an applicant review."""
+# @patch("services.mongodb_handler.raw_update_one", autospec=True)
+# @patch("services.mongodb_handler.retrieve_one", autospec=True)
+# def test_can_submit_review(
+#     mock_mongodb_handler_retrieve_one: AsyncMock,
+#     mock_mongodb_handler_raw_update_one: AsyncMock,
+# ) -> None:
+#     """Test that a user can properly submit an applicant review."""
 
-    mock_mongodb_handler_retrieve_one.return_value = REVIEWER_IDENTITY
+#     mock_mongodb_handler_retrieve_one.return_value = REVIEWER_IDENTITY
 
-    res = reviewer_client.post(
-        "/review",
-        json={"applicant": "edu.uci.applicant", "decision": Decision.ACCEPTED},
-    )
+#     res = reviewer_client.post(
+#         "/review",
+#         json={"applicant": "edu.uci.applicant", "decision": Decision.ACCEPTED},
+#     )
 
-    mock_mongodb_handler_retrieve_one.assert_awaited_once()
-    mock_mongodb_handler_raw_update_one.assert_awaited_once_with(
-        Collection.USERS,
-        {"_id": "edu.uci.applicant"},
-        {
-            "$push": {
-                "application_data.reviews": (ANY, "edu.uci.alicia", Decision.ACCEPTED)
-            },
-            "$set": {"status": "REVIEWED"},
-        },
-    )
-    assert res.status_code == 200
+#     mock_mongodb_handler_retrieve_one.assert_awaited_once()
+#     mock_mongodb_handler_raw_update_one.assert_awaited_once_with(
+#         Collection.USERS,
+#         {"_id": "edu.uci.applicant"},
+#         {
+#             "$push": {
+#                 "application_data.reviews": (ANY, "edu.uci.alicia", Decision.ACCEPTED)
+#             },
+#             "$set": {"status": "REVIEWED"},
+#         },
+#     )
+#     assert res.status_code == 200
 
 
 @patch("services.mongodb_handler.update", autospec=True)


### PR DESCRIPTION
Resolves #330. Review POST route commented out to ensure no accidental review changes after decisions were released. However, the front end still has the review page and button to review.