### PR TITLE
Show check-ins per day in Participants table

### DIFF
--- a/apps/site/src/app/admin/participants/components/CheckinDayIcon.tsx
+++ b/apps/site/src/app/admin/participants/components/CheckinDayIcon.tsx
@@ -1,0 +1,38 @@
+import Icon from "@cloudscape-design/components/icon";
+import dayjs from "dayjs";
+import timezone from "dayjs/plugin/timezone";
+import utc from "dayjs/plugin/utc";
+
+import { Checkin } from "@/lib/admin/useParticipants";
+
+dayjs.extend(utc);
+dayjs.extend(timezone);
+const EVENT_TIMEZONE = "America/Los_Angeles";
+
+interface CheckinDayProps {
+	checkins: Checkin[];
+	date: Date;
+}
+
+const today = dayjs().tz(EVENT_TIMEZONE);
+
+function CheckinDayIcon({ checkins, date }: CheckinDayProps) {
+	// Timezones are weird, but comparing the days of the check-ins
+	const day = dayjs(date).tz(EVENT_TIMEZONE);
+	const checkinTimes = checkins.map(([datetime]) =>
+		dayjs(datetime).tz(EVENT_TIMEZONE),
+	);
+
+	const checkedIn = checkinTimes.some((checkin) => day.isSame(checkin, "date"));
+	const past = day.isBefore(today, "date");
+
+	if (checkedIn) {
+		return <Icon name="status-positive" variant="success" alt="Checked in" />;
+	}
+	if (past) {
+		return <Icon name="status-negative" variant="error" alt="No show" />;
+	}
+	return <Icon name="status-pending" variant="subtle" alt="Pending" />;
+}
+
+export default CheckinDayIcon;

--- a/apps/site/src/app/admin/participants/components/ParticipantsTable.tsx
+++ b/apps/site/src/app/admin/participants/components/ParticipantsTable.tsx
@@ -9,8 +9,13 @@ import TextFilter from "@cloudscape-design/components/text-filter";
 import ApplicantStatus from "@/app/admin/applicants/components/ApplicantStatus";
 import { Participant } from "@/lib/admin/useParticipants";
 
+import CheckinDayIcon from "./CheckinDayIcon";
 import ParticipantAction from "./ParticipantAction";
 import RoleBadge from "./RoleBadge";
+
+const FRIDAY = new Date("2024-01-26T12:00:00");
+const SATURDAY = new Date("2024-01-27T12:00:00");
+const SUNDAY = new Date("2024-01-28T12:00:00");
 
 interface ParticipantsTableProps {
 	participants: Participant[];
@@ -84,6 +89,24 @@ function ParticipantsTable({
 					sortingField: "status",
 				},
 				{
+					id: "friday",
+					header: "Fri",
+					cell: FridayCheckin,
+					sortingField: "friday",
+				},
+				{
+					id: "saturday",
+					header: "Sat",
+					cell: SaturdayCheckin,
+					sortingField: "saturday",
+				},
+				{
+					id: "sunday",
+					header: "Sun",
+					cell: SundayCheckin,
+					sortingField: "sunday",
+				},
+				{
 					id: "action",
 					header: "Action",
 					cell: ActionCell,
@@ -95,7 +118,6 @@ function ParticipantsTable({
 			items={participants}
 			loading={loading}
 			loadingText="Loading participants"
-			resizableColumns
 			variant="full-page"
 			stickyColumns={{ first: 1, last: 0 }}
 			trackBy="_id"
@@ -108,5 +130,17 @@ function ParticipantsTable({
 		/>
 	);
 }
+
+const FridayCheckin = ({ checkins }: Participant) => (
+	<CheckinDayIcon checkins={checkins} date={FRIDAY} />
+);
+
+const SaturdayCheckin = ({ checkins }: Participant) => (
+	<CheckinDayIcon checkins={checkins} date={SATURDAY} />
+);
+
+const SundayCheckin = ({ checkins }: Participant) => (
+	<CheckinDayIcon checkins={checkins} date={SUNDAY} />
+);
 
 export default ParticipantsTable;

--- a/apps/site/src/lib/admin/useParticipants.ts
+++ b/apps/site/src/lib/admin/useParticipants.ts
@@ -15,11 +15,14 @@ const enum Role {
 	WorkshopLead = "workshop_lead",
 }
 
+export type Checkin = [string, Uid];
+
 export interface Participant {
 	_id: Uid;
 	first_name: string;
 	last_name: string;
 	role: Role;
+	checkins: Checkin[];
 	status: Status;
 }
 


### PR DESCRIPTION
As part of #344.
- Provide checkins list in participants endpoint
- Add columns for each day of the event with an icon on check-in status
- Disable resizable columns

## Testing
1. Add sample applicant records with `ATTENDING` status if you don't have them already
2. Load the Participants page on the Admin site
3. Observe the check-in icons are all pending
4. Check in an applicant
5. Refocus the page to trigger a refetch (since we don't have the mutation yet)
6. Observe the icon for Friday has changed to positive