### PR TITLE
Add non-hackers to `/participants` endpoint

### DIFF
--- a/apps/api/src/admin/participant_manager.py
+++ b/apps/api/src/admin/participant_manager.py
@@ -23,7 +23,7 @@ class Participant(UserRecord):
 
     first_name: str
     last_name: str
-    status: Optional[Union[Status, Decision]] = None
+    status: Union[Status, Decision] = Status.REVIEWED
 
 
 async def get_hackers() -> list[Participant]:

--- a/apps/api/src/admin/participant_manager.py
+++ b/apps/api/src/admin/participant_manager.py
@@ -52,24 +52,15 @@ async def get_non_hackers() -> list[Participant]:
     records: list[dict[str, Any]] = await mongodb_handler.retrieve(
         Collection.USERS,
         {
-            "$and": [
-                {"role": {"$exists": True}},
-                {
-                    "role": {
-                        "$not": {
-                            "$regex": "applicant|"
-                            + "|".join(
-                                (
-                                    Role.DIRECTOR,
-                                    Role.REVIEWER,
-                                    Role.CHECKIN_LEAD,
-                                    Role.ORGANIZER,
-                                )
-                            )
-                        }
-                    }
-                },
-            ]
+            "role": {
+                "$in": [
+                    Role.JUDGE,
+                    Role.SPONSOR,
+                    Role.MENTOR,
+                    Role.VOLUNTEER,
+                    Role.WORKSHOP_LEAD,
+                ]
+            }
         },
         ["_id", "status", "role", "first_name", "last_name"],
     )

--- a/apps/api/src/routers/admin.py
+++ b/apps/api/src/routers/admin.py
@@ -248,8 +248,9 @@ async def waitlist_release(uid: str) -> None:
 @router.get("/participants", dependencies=[Depends(require_checkin_associate)])
 async def participants() -> list[Participant]:
     """Get list of participants."""
-    # TODO: non-hackers
-    return await participant_manager.get_hackers()
+    return (await participant_manager.get_hackers()) + (
+        await participant_manager.get_non_hackers()
+    )
 
 
 @router.post("/checkin/{uid}")

--- a/apps/api/src/routers/admin.py
+++ b/apps/api/src/routers/admin.py
@@ -248,9 +248,9 @@ async def waitlist_release(uid: str) -> None:
 @router.get("/participants", dependencies=[Depends(require_checkin_associate)])
 async def participants() -> list[Participant]:
     """Get list of participants."""
-    return (await participant_manager.get_hackers()) + (
-        await participant_manager.get_non_hackers()
-    )
+    hackers = await participant_manager.get_hackers()
+    non_hackers = await participant_manager.get_non_hackers()
+    return hackers + non_hackers
 
 
 @router.post("/checkin/{uid}")


### PR DESCRIPTION
Resolves #364.

## Changes
- Create a new function `get_non_hackers` in `participant_manager` to pull non-hackers from the database
  - The query for this function checks whether a role exists and if it does, whether that role is not an applicant or organizer role
- Return concatenation of hackers and non-hackers in the function for the `/admin/participants` route