### PR TITLE
Confirm non-hacker attendance from PMS

### DIFF
--- a/apps/site/src/app/admin/participants/Participants.tsx
+++ b/apps/site/src/app/admin/participants/Participants.tsx
@@ -14,6 +14,7 @@ function Participants() {
 		loading,
 		checkInParticipant,
 		releaseParticipantFromWaitlist,
+		confirmNonHacker,
 	} = useParticipants();
 	const [checkinParticipant, setCheckinParticipant] =
 		useState<Participant | null>(null);
@@ -49,6 +50,7 @@ function Participants() {
 				loading={loading}
 				initiateCheckIn={initiateCheckIn}
 				initiatePromotion={initiatePromotion}
+				initiateConfirm={confirmNonHacker}
 			/>
 			<CheckInModal
 				onDismiss={() => setCheckinParticipant(null)}
@@ -60,7 +62,6 @@ function Participants() {
 				onConfirm={sendWaitlistPromote}
 				participant={promoteParticipant}
 			/>
-			{/* TODO: walk-in promotion modal */}
 		</>
 	);
 }

--- a/apps/site/src/app/admin/participants/components/ParticipantAction.tsx
+++ b/apps/site/src/app/admin/participants/components/ParticipantAction.tsx
@@ -61,7 +61,7 @@ function ParticipantAction({
 		</Button>
 	);
 
-	if (nonHacker) {
+	if (nonHacker && isWaiverSigned) {
 		if (role !== "director") {
 			return (
 				<ParticipantActionPopover content="Only directors are allowed to confirm non-hackers.">

--- a/apps/site/src/app/admin/participants/components/ParticipantAction.tsx
+++ b/apps/site/src/app/admin/participants/components/ParticipantAction.tsx
@@ -3,7 +3,7 @@ import { useContext } from "react";
 import Button from "@cloudscape-design/components/button";
 
 import UserContext from "@/lib/admin/UserContext";
-import { isCheckinLead } from "@/lib/admin/authorization";
+import { isCheckinLead, isNonHacker } from "@/lib/admin/authorization";
 import { Status } from "@/lib/admin/useApplicant";
 import { Participant } from "@/lib/admin/useParticipants";
 import ParticipantActionPopover from "./ParticipantActionPopover";
@@ -12,18 +12,21 @@ interface ParticipantActionProps {
 	participant: Participant;
 	initiateCheckIn: (participant: Participant) => void;
 	initiatePromotion: (participant: Participant) => void;
+	initiateConfirm: (participant: Participant) => void;
 }
 
 function ParticipantAction({
 	participant,
 	initiateCheckIn,
 	initiatePromotion,
+	initiateConfirm,
 }: ParticipantActionProps) {
 	const { role } = useContext(UserContext);
 
 	const isCheckin = isCheckinLead(role);
 	const isWaiverSigned = participant.status === Status.signed;
 	const isAccepted = participant.status === Status.accepted;
+	const nonHacker = isNonHacker(participant.role);
 
 	const promoteButton = (
 		<Button
@@ -47,7 +50,27 @@ function ParticipantAction({
 		</Button>
 	);
 
-	if (participant.status === Status.waitlisted) {
+	const confirmButton = (
+		<Button
+			variant="inline-link"
+			ariaLabel={`Confirm attendance for ${participant._id}`}
+			onClick={() => initiateConfirm(participant)}
+			disabled={!isCheckin}
+		>
+			Confirm
+		</Button>
+	);
+
+	if (nonHacker) {
+		if (role !== "director") {
+			return (
+				<ParticipantActionPopover content="Only directors are allowed to confirm non-hackers.">
+					{confirmButton}
+				</ParticipantActionPopover>
+			);
+		}
+		return confirmButton;
+	} else if (participant.status === Status.waitlisted) {
 		if (!isCheckin) {
 			return (
 				<ParticipantActionPopover content="Only check-in leads are allowed to promote walk-ins.">

--- a/apps/site/src/app/admin/participants/components/ParticipantsTable.tsx
+++ b/apps/site/src/app/admin/participants/components/ParticipantsTable.tsx
@@ -17,6 +17,7 @@ interface ParticipantsTableProps {
 	loading: boolean;
 	initiateCheckIn: (participant: Participant) => void;
 	initiatePromotion: (participant: Participant) => void;
+	initiateConfirm: (participant: Participant) => void;
 }
 
 function ParticipantsTable({
@@ -24,6 +25,7 @@ function ParticipantsTable({
 	loading,
 	initiateCheckIn,
 	initiatePromotion,
+	initiateConfirm,
 }: ParticipantsTableProps) {
 	// TODO: sorting
 	// TODO: search functionality
@@ -35,9 +37,10 @@ function ParticipantsTable({
 				participant={participant}
 				initiateCheckIn={initiateCheckIn}
 				initiatePromotion={initiatePromotion}
+				initiateConfirm={initiateConfirm}
 			/>
 		),
-		[initiateCheckIn, initiatePromotion],
+		[initiateCheckIn, initiatePromotion, initiateConfirm],
 	);
 
 	const emptyMessage = (

--- a/apps/site/src/lib/admin/authorization.ts
+++ b/apps/site/src/lib/admin/authorization.ts
@@ -24,6 +24,7 @@ export function isCheckinLead(role: string | null) {
 	return role !== null && CHECKIN_ROLES.includes(role);
 }
 
+// refactor: this function should be placed elsewhere later
 export function isNonHacker(role: string | null) {
 	return role !== null && NONHACKER_ROLES.includes(role);
 }

--- a/apps/site/src/lib/admin/authorization.ts
+++ b/apps/site/src/lib/admin/authorization.ts
@@ -1,6 +1,13 @@
 const ADMIN_ROLES = ["director", "reviewer", "checkin_lead"];
 const CHECKIN_ROLES = ["director", "checkin_lead"];
 const ORGANIZER_ROLES = ["organizer"];
+const NONHACKER_ROLES = [
+	"judge",
+	"sponsor",
+	"mentor",
+	"volunteer",
+	"workshop_lead",
+];
 
 export function isApplicationManager(role: string | null) {
 	return role !== null && ADMIN_ROLES.includes(role);
@@ -15,4 +22,8 @@ export function isAdminRole(role: string | null) {
 
 export function isCheckinLead(role: string | null) {
 	return role !== null && CHECKIN_ROLES.includes(role);
+}
+
+export function isNonHacker(role: string | null) {
+	return role !== null && NONHACKER_ROLES.includes(role);
 }

--- a/apps/site/src/lib/admin/useParticipants.ts
+++ b/apps/site/src/lib/admin/useParticipants.ts
@@ -1,5 +1,5 @@
 import axios from "axios";
-import useSWR from "swr";
+import useSWR, { mutate } from "swr";
 
 import { Status, Uid } from "@/lib/admin/useApplicant";
 
@@ -38,17 +38,20 @@ function useParticipants() {
 		console.log("Checking in", participant);
 		// TODO: implement mutation for showing checked in on each day
 		await axios.post(`/api/admin/checkin/${participant._id}`);
+		mutate(data);
 	};
 
 	const releaseParticipantFromWaitlist = async (participant: Participant) => {
 		console.log(`Promoted to waitlist`, participant);
 		// TODO: implement mutation for showing checked in on each day
 		await axios.post(`/api/admin/waitlist-release/${participant._id}`);
+		mutate(data);
 	};
 
 	const confirmNonHacker = async (participant: Participant) => {
 		console.log("Confirmed attendance for non-hacker", participant);
 		await axios.post(`/api/admin/update-attendance/${participant._id}`);
+		mutate(data);
 	};
 
 	return {

--- a/apps/site/src/lib/admin/useParticipants.ts
+++ b/apps/site/src/lib/admin/useParticipants.ts
@@ -1,5 +1,5 @@
 import axios from "axios";
-import useSWR, { mutate } from "swr";
+import useSWR from "swr";
 
 import { Status, Uid } from "@/lib/admin/useApplicant";
 
@@ -29,7 +29,7 @@ const fetcher = async (url: string) => {
 };
 
 function useParticipants() {
-	const { data, error, isLoading } = useSWR<Participant[]>(
+	const { data, error, isLoading, mutate } = useSWR<Participant[]>(
 		"/api/admin/participants",
 		fetcher,
 	);
@@ -38,20 +38,20 @@ function useParticipants() {
 		console.log("Checking in", participant);
 		// TODO: implement mutation for showing checked in on each day
 		await axios.post(`/api/admin/checkin/${participant._id}`);
-		mutate(data);
+		mutate();
 	};
 
 	const releaseParticipantFromWaitlist = async (participant: Participant) => {
 		console.log(`Promoted to waitlist`, participant);
 		// TODO: implement mutation for showing checked in on each day
 		await axios.post(`/api/admin/waitlist-release/${participant._id}`);
-		mutate(data);
+		mutate();
 	};
 
 	const confirmNonHacker = async (participant: Participant) => {
 		console.log("Confirmed attendance for non-hacker", participant);
 		await axios.post(`/api/admin/update-attendance/${participant._id}`);
-		mutate(data);
+		mutate();
 	};
 
 	return {

--- a/apps/site/src/lib/admin/useParticipants.ts
+++ b/apps/site/src/lib/admin/useParticipants.ts
@@ -46,12 +46,18 @@ function useParticipants() {
 		await axios.post(`/api/admin/waitlist-release/${participant._id}`);
 	};
 
+	const confirmNonHacker = async (participant: Participant) => {
+		console.log("Confirmed attendance for non-hacker", participant);
+		await axios.post(`/api/admin/update-attendance/${participant._id}`);
+	};
+
 	return {
 		participants: data ?? [],
 		loading: isLoading,
 		error,
 		checkInParticipant,
 		releaseParticipantFromWaitlist,
+		confirmNonHacker,
 	};
 }
 


### PR DESCRIPTION
Resolves #356.

## Changes
- Update ParticipantAction to show Confirm button when participant's role is not applicant
  - Send POST request to endpoint from https://github.com/HackAtUCI/irvinehacks-site-2024/issues/322
- Disable the button when the user is not a director and show a corresponding tooltip/popover