### PR TITLE
Allow check-in leads to confirm non-hackers

### DIFF
--- a/apps/api/src/routers/admin.py
+++ b/apps/api/src/routers/admin.py
@@ -271,7 +271,10 @@ async def check_in_participant(
     "/update-attendance/{uid}",
 )
 async def update_attendance(
-    uid: str, director: Annotated[User, Depends(require_role([Role.DIRECTOR]))]
+    uid: str,
+    director: Annotated[
+        User, Depends(require_role([Role.DIRECTOR, Role.CHECKIN_LEAD]))
+    ],
 ) -> None:
     """Update status to Role.ATTENDING for non-hackers."""
     try:


### PR DESCRIPTION
As part of #318 and as requested by Alicia, allow check-in leads to confirm attendance of non-hackers since directors are busy. All participants will still need waiver signed.