### PR TITLE
Implement badge barcode scanning

### DIFF
--- a/apps/api/src/routers/admin.py
+++ b/apps/api/src/routers/admin.py
@@ -255,11 +255,13 @@ async def participants() -> list[Participant]:
 
 @router.post("/checkin/{uid}")
 async def check_in_participant(
-    uid: str, associate: Annotated[User, Depends(require_checkin_associate)]
+    uid: str,
+    badge_number: Annotated[str, Body()],
+    associate: Annotated[User, Depends(require_checkin_associate)],
 ) -> None:
     """Check in participant at IrvineHacks."""
     try:
-        await participant_manager.check_in_participant(uid, associate)
+        await participant_manager.check_in_participant(uid, badge_number, associate)
     except ValueError:
         raise HTTPException(status.HTTP_404_NOT_FOUND)
     except RuntimeError as err:

--- a/apps/site/package.json
+++ b/apps/site/package.json
@@ -28,6 +28,7 @@
 		"date-fns-tz": "^2.0.0",
 		"dayjs": "^1.11.10",
 		"framer-motion": "^10.16.14",
+		"html5-qrcode": "^2.3.8",
 		"lucide-react": "^0.292.0",
 		"next": "13.5.6",
 		"next-sanity": "^5.5.4",

--- a/apps/site/src/lib/admin/BadgeScanner.tsx
+++ b/apps/site/src/lib/admin/BadgeScanner.tsx
@@ -1,0 +1,56 @@
+import { useEffect } from "react";
+
+import {
+	Html5QrcodeScanner,
+	QrcodeErrorCallback,
+	QrcodeSuccessCallback,
+} from "html5-qrcode";
+
+const scannerRegionId = "badge-scanner-full-region";
+
+interface BadgeScannerProps {
+	fps?: number;
+	qrbox?: number;
+	aspectRatio?: number;
+	disableFlip?: boolean;
+	verbose?: boolean;
+	onSuccess: QrcodeSuccessCallback;
+	onError: QrcodeErrorCallback;
+}
+
+function BadgeScanner(props: BadgeScannerProps) {
+	useEffect(() => {
+		const {
+			fps,
+			qrbox,
+			aspectRatio,
+			disableFlip,
+			verbose,
+			onSuccess,
+			onError,
+		} = props;
+
+		const html5QrcodeScanner = new Html5QrcodeScanner(
+			scannerRegionId,
+			{
+				fps: fps ?? 5,
+				qrbox: qrbox ?? 300,
+				aspectRatio: aspectRatio ?? 1,
+				disableFlip: disableFlip ?? true,
+			},
+			verbose ?? false,
+		);
+		html5QrcodeScanner.render(onSuccess, onError);
+
+		// Clean up when unmount
+		return () => {
+			html5QrcodeScanner.clear().catch((error) => {
+				console.error("Failed to clear html5QrcodeScanner. ", error);
+			});
+		};
+	}, [props]);
+
+	return <div id={scannerRegionId} />;
+}
+
+export default BadgeScanner;

--- a/apps/site/src/lib/admin/useParticipants.ts
+++ b/apps/site/src/lib/admin/useParticipants.ts
@@ -24,6 +24,7 @@ export interface Participant {
 	role: Role;
 	checkins: Checkin[];
 	status: Status;
+	badge_number: string | null;
 }
 
 const fetcher = async (url: string) => {
@@ -40,7 +41,12 @@ function useParticipants() {
 	const checkInParticipant = async (participant: Participant) => {
 		console.log("Checking in", participant);
 		// TODO: implement mutation for showing checked in on each day
-		await axios.post(`/api/admin/checkin/${participant._id}`);
+		// Note: Will cause 422 if badge number is null, but in practice,
+		// this should never happen
+		await axios.post(
+			`/api/admin/checkin/${participant._id}`,
+			participant.badge_number,
+		);
 	};
 
 	const releaseParticipantFromWaitlist = async (participant: Participant) => {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -141,6 +141,9 @@ importers:
       framer-motion:
         specifier: ^10.16.14
         version: 10.16.14(react-dom@18.2.0)(react@18.2.0)
+      html5-qrcode:
+        specifier: ^2.3.8
+        version: 2.3.8
       lucide-react:
         specifier: ^0.292.0
         version: 0.292.0(react@18.2.0)
@@ -7285,6 +7288,10 @@ packages:
     engines: {node: '>=12'}
     dependencies:
       whatwg-encoding: 2.0.0
+    dev: false
+
+  /html5-qrcode@2.3.8:
+    resolution: {integrity: sha512-jsr4vafJhwoLVEDW3n1KvPnCCXWaQfRng0/EEYk1vNcQGcG/htAdhJX0be8YyqMoSz7+hZvOZSTAepsabiuhiQ==}
     dev: false
 
   /http-proxy-agent@5.0.0:


### PR DESCRIPTION
still buggy, we need to ship now
- Install `html5-qrcode` for scanning barcodes
- Store and provide badge number for participants
  - Update check-in POST request to send badge number
  - Update check-in endpoint to store badge number
  - Update participants endpoint to provide badge numbers
- Implement badge scanner with html5-qrcode
  - Still some weird `useEffect` issues with scanner opening twice